### PR TITLE
Add signed delivery URLs and transform service

### DIFF
--- a/apps/api/env.template
+++ b/apps/api/env.template
@@ -11,6 +11,9 @@ BETTER_AUTH_URL=http://localhost:3000
 # Mode: "fullstack" = with web UI (default), "api" = API standalone (auto-generates API key)
 # MODE=fullstack
 
+# Generate a secret API key that will be used for signed delivery URLs
+# API_SECRET=mysecretkey
+
 # PORT=3000
 
 # CORS_ORIGIN=http://localhost:3001

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,42 +1,42 @@
-import { Hono } from "hono";
-import { cors } from "hono/cors";
-import transform from "./routes/transform";
-import upload from "./routes/upload";
-import storageRoute from "./routes/storage";
-import apiKeys from "./routes/api-keys";
-import health from "./routes/health";
-import videoStatus from "./routes/video-status";
-import logger from "./utils/logger";
-import queueEvents from "./routes/queue-events";
-import queue from "./routes/queue";
-import invalidateRoute from "./routes/invalidate";
-import { apiKeyAuth } from "./middleware/auth";
-import { publicRateLimit } from "./middleware/rate-limit";
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import transform from './routes/transform';
+import authenticated from './routes/authenticated';
+import upload from './routes/upload';
+import storageRoute from './routes/storage';
+import apiKeys from './routes/api-keys';
+import health from './routes/health';
+import videoStatus from './routes/video-status';
+import queueEvents from './routes/queue-events';
+import queue from './routes/queue';
+import invalidateRoute from './routes/invalidate';
+import { apiKeyAuth } from './middleware/auth';
+import { publicRateLimit } from './middleware/rate-limit';
 
 const app = new Hono();
 
 // CORS - Allow credentials for session cookies
 app.use(
-  "/*",
+  '/*',
   cors({
     origin: (origin) => {
       // Allow requests from Next.js app or configured origins
       const allowedOrigins = [
-        "http://localhost:3001", // Next.js dev
-        "http://localhost:3000", // API itself
+        'http://localhost:3001', // Next.js dev
+        'http://localhost:3000', // API itself
         process.env.CORS_ORIGIN,
       ].filter(Boolean);
 
-      if (!origin || allowedOrigins.includes("*")) {
-        return origin || "*";
+      if (!origin || allowedOrigins.includes('*')) {
+        return origin || '*';
       }
 
       return allowedOrigins.includes(origin) ? origin : allowedOrigins[0];
     },
-    allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
-    allowHeaders: ["Content-Type", "Authorization", "Cookie"],
+    allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'],
+    allowHeaders: ['Content-Type', 'Authorization', 'Cookie'],
     credentials: true, // Important: allow cookies
-    exposeHeaders: ["Set-Cookie"],
+    exposeHeaders: ['Set-Cookie'],
   })
 );
 
@@ -44,47 +44,54 @@ app.use(
 // Rate limiting is applied to these routes only (protected routes have their own rate limiting via better-auth)
 
 // Root endpoint
-app.get("/", publicRateLimit, (c) => c.text("Openinary API Server is running."));
+app.get('/', publicRateLimit, (c) =>
+  c.text('Openinary API Server is running.')
+);
 
 // Health check routes
-app.use("/health", publicRateLimit);
-app.use("/health/*", publicRateLimit);
-app.route("/health", health);
+app.use('/health', publicRateLimit);
+app.use('/health/*', publicRateLimit);
+app.route('/health', health);
 
 // Video status check (public - no auth required)
-app.use("/video-status", publicRateLimit);
-app.use("/video-status/*", publicRateLimit);
-app.route("/video-status", videoStatus);
+app.use('/video-status', publicRateLimit);
+app.use('/video-status/*', publicRateLimit);
+app.route('/video-status', videoStatus);
 
-// Image transformation route is public for easy access to transformed images
-app.use("/t", publicRateLimit);
-app.use("/t/*", publicRateLimit);
-app.route("/t", transform);
+// Image transformation routes (public for easy access to transformed images)
+app.use('/t', publicRateLimit);
+app.use('/t/*', publicRateLimit);
+app.route('/t', transform);
+
+// Authenticated image transformation route (with signature verification)
+app.use('/authenticated', publicRateLimit);
+app.use('/authenticated/*', publicRateLimit);
+app.route('/authenticated', authenticated);
 
 // Queue events SSE endpoint (public for real-time updates)
 // This must be registered BEFORE the protected queue routes to avoid auth conflicts
-app.use("/queue/events", publicRateLimit);
-app.use("/queue/events/*", publicRateLimit);
-app.route("/queue/events", queueEvents);
+app.use('/queue/events', publicRateLimit);
+app.use('/queue/events/*', publicRateLimit);
+app.route('/queue/events', queueEvents);
 
 // Protected routes - require API key authentication
 // Apply middleware before routing
-app.use("/upload/*", apiKeyAuth);
-app.route("/upload", upload);
+app.use('/upload/*', apiKeyAuth);
+app.route('/upload', upload);
 
-app.use("/storage/*", apiKeyAuth);
-app.route("/storage", storageRoute);
+app.use('/storage/*', apiKeyAuth);
+app.route('/storage', storageRoute);
 
 // Cache invalidation route (protected)
-app.use("/invalidate/*", apiKeyAuth);
-app.route("/invalidate", invalidateRoute);
+app.use('/invalidate/*', apiKeyAuth);
+app.route('/invalidate', invalidateRoute);
 
 // Queue management routes (protected)
 // Note: /queue/events is public (registered above), but other /queue/* routes require auth
-app.use("/queue/*", apiKeyAuth);
-app.route("/queue", queue);
+app.use('/queue/*', apiKeyAuth);
+app.route('/queue', queue);
 
 // API key management routes (also protected)
-app.route("/api-keys", apiKeys);
+app.route('/api-keys', apiKeys);
 
 export default app;

--- a/apps/api/src/routes/authenticated.ts
+++ b/apps/api/src/routes/authenticated.ts
@@ -1,0 +1,160 @@
+import { Hono } from 'hono';
+import { TransformService } from '../services/transform.service';
+import logger from '../utils/logger';
+import crypto from 'crypto';
+
+const t = new Hono();
+const transformService = new TransformService();
+
+// Get API_SECRET from environment variables
+const API_SECRET = process.env.API_SECRET;
+
+if (!API_SECRET) {
+  logger.warn(
+    'API_SECRET environment variable is not set. Authenticated route will not work properly.'
+  );
+}
+
+t.get('/*', async (c) => {
+  const path = c.req.path;
+  const userAgent = c.req.header('User-Agent');
+  const acceptHeader = c.req.header('Accept');
+
+  try {
+    // Parse the authenticated URL format: /s--{signature}/{transformations}/{route}
+    const segments = path.split('/').slice(2); // Remove '/s' prefix
+
+    if (segments.length < 2) {
+      return c.text(
+        'Invalid authenticated URL format. Expected: /s--{signature}/{transformations}/{route}',
+        400
+      );
+    }
+
+    // Extract signature from first segment (format: s--{signature})
+    const firstSegment = segments[0];
+    if (!firstSegment.startsWith('s--')) {
+      return c.text('Invalid signature format. Expected: s--{signature}', 400);
+    }
+
+    const signature = firstSegment.slice(3); // Remove 's--' prefix
+
+    if (signature.length !== 8) {
+      return c.text('Invalid signature length. Expected 8 characters.', 400);
+    }
+
+    // Extract transformations and route from remaining segments
+    const routeSegments = segments.slice(1);
+    if (routeSegments.length < 1) {
+      return c.text('No route specified.', 400);
+    }
+
+    // Determine transformation string and file path
+    // Format: {transformations}/{route}
+    const hasTransform =
+      routeSegments.length > 0 &&
+      !routeSegments[0].includes('.') &&
+      (routeSegments[0].includes(',') || routeSegments[0].includes('_'));
+
+    const transformations = hasTransform ? routeSegments[0] : '';
+    const filePathSegments = hasTransform
+      ? routeSegments.slice(1)
+      : routeSegments;
+    const filePath = filePathSegments.join('/');
+
+    if (!filePath) {
+      return c.text('No file path specified.', 400);
+    }
+
+    // Verify the signature
+    if (!API_SECRET) {
+      return c.text('API_SECRET not configured on server.', 500);
+    }
+
+    // Create the string to sign: {transformations}/{filePath}{API_SECRET}
+    const stringToSign = hasTransform
+      ? `${transformations}/${filePath}${API_SECRET}`
+      : `${filePath}${API_SECRET}`;
+
+    // Compute SHA-1 hash
+    const hash = crypto.createHash('sha1');
+    hash.update(stringToSign);
+    const hashHex = hash.digest('hex');
+
+    // Take first 8 characters for comparison
+    const computedSignature = hashHex.substring(0, 8);
+
+    // Verify signature matches
+    if (computedSignature !== signature) {
+      logger.warn(
+        {
+          path,
+          signature,
+          computedSignature,
+          stringToSign,
+        },
+        'Invalid signature for authenticated request'
+      );
+
+      return c.text('Invalid signature', 401);
+    }
+
+    // Construct the path for the transform service
+    // Format: /t/{transformations}/{filePath}
+    const transformPath = `/t/${transformations ? transformations + '/' : ''}${filePath}`;
+
+    // Use the transform service with the constructed path
+    const result = await transformService.transform({
+      path: transformPath,
+      userAgent,
+      acceptHeader,
+      context: c,
+    });
+
+    // Set response headers
+    Object.entries(result.headers).forEach(([key, value]) => {
+      c.header(key, value);
+    });
+
+    // Determine content type if not set in headers
+    if (!result.contentType) {
+      // Extract file extension from path
+      const ext = filePath.split('.').pop()?.toLowerCase();
+      const contentTypeMap: Record<string, string> = {
+        jpg: 'image/jpeg',
+        jpeg: 'image/jpeg',
+        png: 'image/png',
+        webp: 'image/webp',
+        avif: 'image/avif',
+        gif: 'image/gif',
+        mp4: 'video/mp4',
+        mov: 'video/quicktime',
+        webm: 'video/webm',
+      };
+      const contentType =
+        contentTypeMap[ext || ''] || 'application/octet-stream';
+      c.header('Content-Type', contentType);
+    } else {
+      c.header('Content-Type', result.contentType);
+    }
+
+    // Check if this is an error response
+    if (
+      result.contentType === 'text/plain' &&
+      result.buffer.toString().includes('failed')
+    ) {
+      const errorMessage = result.buffer.toString();
+      if (errorMessage.includes('File not found')) {
+        return c.text(errorMessage, 404);
+      }
+      return c.text(errorMessage, 500);
+    }
+
+    return c.body(new Uint8Array(result.buffer));
+  } catch (error) {
+    logger.error({ error, path }, 'Authenticated transform route error');
+    return c.text('Internal server error', 500);
+  }
+});
+
+export default t;

--- a/apps/api/src/routes/authenticated.ts
+++ b/apps/api/src/routes/authenticated.ts
@@ -17,7 +17,7 @@ if (!API_SECRET) {
 
 t.get('/*', async (c) => {
   const path = c.req.path;
-  const userAgent = c.req.header('User-Agent');
+  const userAgent = c.req.header('User-Agent') ?? '';
   const acceptHeader = c.req.header('Accept');
 
   try {

--- a/apps/api/src/routes/transform.ts
+++ b/apps/api/src/routes/transform.ts
@@ -1,336 +1,66 @@
-import { Hono } from "hono";
-import { getCachePath, existsInCache } from "../utils/cache";
-import { parseParams } from "../utils/parser";
-import { createStorageClient } from "../utils/storage/index";
-import { Compression } from "../utils/image/compression";
-import logger from "../utils/logger";
-import { videoJobQueue } from "../utils/video-job-queue";
-import { updateJobStatus } from "../utils/video/queue-db";
-import { readFile } from "fs/promises";
-import {
-  setContentTypeHeader,
-  checkCloudCache,
-  checkLocalCache,
-  verifyFileExists,
-  prepareSourceFile,
-  processImage,
-  processVideo,
-  saveToCaches,
-  cleanupTempFile,
-  performPeriodicCacheCleanup,
-  determineContentType,
-} from "./transform-helpers";
-import { THUMBNAIL_PRIORITY, TRANSFORMATION_PRIORITY } from "../utils/video/config";
+import { Hono } from 'hono';
+import { TransformService } from '../services/transform.service';
+import logger from '../utils/logger';
 
 const t = new Hono();
-const storage = createStorageClient();
-const compression = new Compression();
+const transformService = new TransformService();
 
-t.get("/*", async (c) => {
+t.get('/*', async (c) => {
   const path = c.req.path;
-  const segments = path.split("/").slice(2); // Remove '/t' prefix
-  const params = parseParams(path);
+  const userAgent = c.req.header('User-Agent');
+  const acceptHeader = c.req.header('Accept');
 
-  // Determine file path segments.
-  // The first segment after "/t" is the transformation string
-  // (e.g. "w_300,h_300,c_fill") and should not be part of the file path.
-  const hasTransform =
-    segments.length > 0 &&
-    !segments[0].includes(".") &&
-    (segments[0].includes(",") || segments[0].includes("_"));
-
-  const fileSegments = hasTransform
-    ? segments.slice(1)
-    : segments;
-  const filePath = fileSegments.join("/");
-
-  let cachePath = getCachePath(path);
-  const localPath = `./public/${filePath}`;
-  const ext = filePath.split(".").pop();
-
-  // Get browser support info for format optimization
-  const userAgent = c.req.header("User-Agent");
-  const acceptHeader = c.req.header("Accept");
-  
-  // Determine optimal format if not explicitly specified
-  // This ensures cache keys include the format for proper cache hits
-  let effectiveParams = { ...params };
-  if (!params.format && ext?.match(/jpe?g|png|webp|avif|gif/)) {
-    const optimalFormat = compression.determineOptimalFormatForCache(
+  try {
+    const result = await transformService.transform({
+      path,
       userAgent,
       acceptHeader,
-      ext
-    );
-    effectiveParams = { ...params, format: optimalFormat };
-    
-    // Update cache path to include the optimal format
-    const pathWithFormat = path.replace(
-      /\/t\/(.*)$/,
-      `/t/format:${optimalFormat}/$1`
-    );
-    cachePath = getCachePath(pathWithFormat);
-  }
-  
-  // 1. FIRST: Verify original file exists (before serving cache)
-  // This prevents serving cached files when the original has been deleted
-  const fileCheck = await verifyFileExists(storage, filePath, localPath);
-  if (!fileCheck.exists) {
-    logger.error({ filePath }, "File not found - invalidating cache");
-    
-    // Delete cached versions since original is gone
-    try {
-      const { deleteCachedFiles } = await import("../utils/cache");
-      await deleteCachedFiles(filePath);
-    } catch (error) {
-      logger.warn({ error, filePath }, "Failed to delete cached files");
-    }
-    
-    // Prevent caching of 404 responses
-    c.header('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
-    c.header('Pragma', 'no-cache');
-    c.header('Expires', '0');
-    
-    return c.text(fileCheck.error || "File not found", 404);
-  }
+      context: c,
+    });
 
-  // 2. Check cloud cache (if configured)
-  const cloudCacheBuffer = await checkCloudCache(storage, filePath, effectiveParams);
-  if (cloudCacheBuffer) {
-    // For cloud cache, we trust it has the right format since it's based on params
-    const contentType = await determineContentType(effectiveParams, cloudCacheBuffer, ext);
-    setContentTypeHeader(c, contentType);
-    // Add cache control headers - allow caching but require revalidation
-    c.header('Cache-Control', 'public, max-age=31536000, must-revalidate');
-    c.header('ETag', `"${filePath}-${JSON.stringify(effectiveParams)}"`);
-    // For videos, indicate this is the optimized version
-    if (ext?.match(/mp4|mov|webm/)) {
-      c.header('X-Video-Status', 'ready');
-      c.header('Content-Length', cloudCacheBuffer.length.toString());
-    }
-    return c.body(new Uint8Array(cloudCacheBuffer));
-  }
+    // Set response headers
+    Object.entries(result.headers).forEach(([key, value]) => {
+      c.header(key, value);
+    });
 
-  // 3. Check local cache (now includes format in key when format is auto-determined)
-  const localCacheBuffer = await checkLocalCache(cachePath);
-  if (localCacheBuffer) {
-    const contentType = await determineContentType(effectiveParams, localCacheBuffer, ext);
-    setContentTypeHeader(c, contentType);
-    // Add cache control headers - allow caching but require revalidation
-    c.header('Cache-Control', 'public, max-age=31536000, must-revalidate');
-    c.header('ETag', `"${filePath}-${JSON.stringify(effectiveParams)}"`);
-    // For videos, indicate this is the optimized version
-    if (ext?.match(/mp4|mov|webm/)) {
-      c.header('X-Video-Status', 'ready');
-      c.header('Content-Length', localCacheBuffer.length.toString());
-    }
-    return c.body(new Uint8Array(localCacheBuffer));
-  }
-
-  // 4. File exists but not in cache - process it
-
-  // 4. Processing and storage
-  try {
-    // Prepare source file (download from cloud if needed)
-    const sourcePath = await prepareSourceFile(storage, filePath, localPath);
-    const isTempFile = !!storage;
-
-    let buffer: Buffer;
-    let contentType: string;
-    let optimizationResult: any;
-
-    // Process based on file type
-    if (ext?.match(/jpe?g|png|webp|avif|gif/)) {
-      const result = await processImage(
-        sourcePath,
-        effectiveParams, // Use effectiveParams which includes auto-determined format
-        userAgent,
-        acceptHeader,
-        compression
-      );
-      buffer = result.buffer;
-      contentType = result.contentType;
-      optimizationResult = result.optimizationResult;
-    } else if (ext?.match(/mp4|mov|webm/)) {
-      // Check if this is a thumbnail extraction (produces image, not video)
-      // Support both string 'true' and '1' (params are always strings from parseParams)
-      const isThumbnailRequest = params.thumbnail === 'true' || params.thumbnail === '1';
-      
-      // For thumbnail extraction: process synchronously (fast, produces image)
-      if (isThumbnailRequest) {
-        const result = await processVideo(sourcePath, params);
-        buffer = result.buffer;
-        contentType = result.contentType;
-      } else {
-        // For video transformations: check if we should process in background
-        // Check if already being processed
-        let existingJob = videoJobQueue.getJobByPath(filePath, params);
-        let shouldRequeue = false;
-        
-        if (existingJob) {
-          logger.debug({ jobId: existingJob.id, status: existingJob.status }, 'Video job exists');
-          
-          // If completed, verify cache actually exists before serving
-          if (existingJob.status === 'completed') {
-            // Check both local and cloud cache
-            const localCacheExists = await existsInCache(cachePath);
-            const cloudCacheExists = storage ? await storage.exists(filePath, params) : false;
-            
-            if (localCacheExists || cloudCacheExists) {
-              // Cache exists, try to serve from local cache first
-              const cachedBuffer = await checkLocalCache(cachePath);
-              if (cachedBuffer) {
-                if (isTempFile) {
-                  await cleanupTempFile(sourcePath);
-                }
-                const cachedContentType = await determineContentType(params, cachedBuffer, ext);
-                setContentTypeHeader(c, cachedContentType);
-                c.header('X-Video-Status', 'ready');
-                c.header('Content-Length', cachedBuffer.length.toString());
-                return c.body(new Uint8Array(cachedBuffer));
-              }
-              
-              // If local cache doesn't exist but cloud does, it will be handled by checkCloudCache above
-              // This should not happen here, but if it does, fall through to queue processing
-            } else {
-              // Job is marked as completed but cache doesn't exist (e.g., after setup/reset)
-              // Reset job to pending and requeue it
-              logger.warn(
-                { jobId: existingJob.id, filePath, cachePath },
-                'Job marked as completed but cache missing - resetting to pending'
-              );
-              try {
-                updateJobStatus(existingJob.id, 'pending', 0);
-                // Mark that we should requeue this job
-                shouldRequeue = true;
-                // Update existingJob status so the condition below works correctly
-                existingJob = { ...existingJob, status: 'pending' as const };
-              } catch (error) {
-                logger.error({ error, jobId: existingJob.id }, 'Failed to reset job status');
-                // Continue anyway - will be handled by the requeue logic below
-                shouldRequeue = true;
-              }
-            }
-          }
-        }
-        
-        // Add to background processing queue (non-blocking)
-        // Use normal priority for video transformations
-        // Requeue if: no job exists, job is in error state, job is pending, or cache was missing
-        if (!existingJob || existingJob.status === 'error' || existingJob.status === 'pending' || shouldRequeue) {
-          videoJobQueue.addJob(filePath, params, cachePath, sourcePath, storage, TRANSFORMATION_PRIORITY).catch((error) => {
-            logger.error({ error, filePath }, 'Failed to add video job');
-          });
-        }
-
-        // Return original video immediately
-        try {
-          const originalBuffer = storage 
-            ? await storage.downloadOriginal(filePath)
-            : await readFile(localPath);
-
-          // Clean up temp file if needed
-          if (isTempFile && sourcePath !== localPath) {
-            await cleanupTempFile(sourcePath);
-          }
-
-          setContentTypeHeader(c, `video/${ext}`);
-          c.header('X-Video-Status', 'processing');
-          c.header('X-Original-Video', 'true');
-          // DO NOT cache original video while processing - CDN must revalidate
-          c.header('Cache-Control', 'public, max-age=0, must-revalidate');
-          c.header('ETag', `"${filePath}-processing-${Date.now()}"`);
-          c.header('Vary', 'Accept');
-          
-          return c.body(new Uint8Array(originalBuffer));
-        } catch (error) {
-          logger.error({ error, filePath }, 'Failed to serve original video');
-          if (isTempFile) {
-            await cleanupTempFile(sourcePath);
-          }
-          return c.text('Failed to load video', 500);
-        }
-      }
+    // Determine content type if not set in headers
+    if (!result.contentType) {
+      // Extract file extension from path
+      const ext = path.split('.').pop()?.toLowerCase();
+      const contentTypeMap: Record<string, string> = {
+        jpg: 'image/jpeg',
+        jpeg: 'image/jpeg',
+        png: 'image/png',
+        webp: 'image/webp',
+        avif: 'image/avif',
+        gif: 'image/gif',
+        mp4: 'video/mp4',
+        mov: 'video/quicktime',
+        webm: 'video/webm',
+      };
+      const contentType =
+        contentTypeMap[ext || ''] || 'application/octet-stream';
+      c.header('Content-Type', contentType);
     } else {
-      // Cleanup temp file if needed
-      if (isTempFile) {
-        await cleanupTempFile(sourcePath);
+      c.header('Content-Type', result.contentType);
+    }
+
+    // Check if this is an error response
+    if (
+      result.contentType === 'text/plain' &&
+      result.buffer.toString().includes('failed')
+    ) {
+      const errorMessage = result.buffer.toString();
+      if (errorMessage.includes('File not found')) {
+        return c.text(errorMessage, 404);
       }
-      return c.text("Unsupported file type", 400);
+      return c.text(errorMessage, 500);
     }
 
-    // Clean up temporary source file if used (when cloud provider configured)
-    if (isTempFile) {
-      await cleanupTempFile(sourcePath);
-    }
-
-    // Save to caches (use effectiveParams to ensure format is included in cache key)
-    await saveToCaches(storage, filePath, effectiveParams, cachePath, buffer, contentType);
-
-    // Periodic cache cleanup
-    await performPeriodicCacheCleanup();
-
-    // Set response headers (use the actual content-type from processing, not the original extension)
-    setContentTypeHeader(c, contentType);
-    c.header('Content-Length', buffer.length.toString());
-    // Add cache control headers - allow caching but require revalidation
-    c.header('Cache-Control', 'public, max-age=31536000, must-revalidate');
-    c.header('ETag', `"${filePath}-${JSON.stringify(effectiveParams)}"`);
-
-    // For videos, indicate this is the optimized version
-    if (ext?.match(/mp4|mov|webm/)) {
-      c.header('X-Video-Status', 'ready');
-    }
-
-    if (optimizationResult) {
-      c.header("X-Original-Size", optimizationResult.originalSize.toString());
-      c.header("X-Optimized-Size", optimizationResult.optimizedSize.toString());
-      c.header(
-        "X-Compression-Ratio",
-        optimizationResult.compressionRatio.toFixed(2)
-      );
-      c.header("X-Savings-Percent", optimizationResult.savings.toFixed(1));
-    }
-
-    return c.body(new Uint8Array(buffer));
+    return c.body(new Uint8Array(result.buffer));
   } catch (error) {
-    logger.error({ error, filePath }, "Processing error");
-    
-    // Check if this is a "file not found" error from cloud storage
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    const isNotFoundError = 
-      errorMessage.includes('NoSuchKey') || 
-      errorMessage.includes('NotFound') || 
-      errorMessage.includes('404') ||
-      errorMessage.includes('does not exist') ||
-      errorMessage.includes('not found');
-    
-    if (isNotFoundError && storage) {
-      // Invalidate cache since the file doesn't exist
-      storage.invalidateAllCacheEntries(filePath);
-      
-      // Delete local cache files
-      try {
-        const { deleteCachedFiles } = await import("../utils/cache");
-        await deleteCachedFiles(filePath);
-      } catch (cleanupError) {
-        logger.warn({ error: cleanupError, filePath }, "Failed to cleanup cache after not found error");
-      }
-      
-      // Prevent caching of 404 responses
-      c.header('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
-      c.header('Pragma', 'no-cache');
-      c.header('Expires', '0');
-      
-      return c.text(
-        `File not found: ${filePath}. Make sure the file exists in your cloud storage bucket.`,
-        404
-      );
-    }
-    
-    return c.text(
-      `Processing failed: ${errorMessage}`,
-      500
-    );
+    logger.error({ error, path }, 'Transform route error');
+    return c.text('Internal server error', 500);
   }
 });
 

--- a/apps/api/src/routes/transform.ts
+++ b/apps/api/src/routes/transform.ts
@@ -7,7 +7,7 @@ const transformService = new TransformService();
 
 t.get('/*', async (c) => {
   const path = c.req.path;
-  const userAgent = c.req.header('User-Agent');
+  const userAgent = c.req.header('User-Agent') ?? '';
   const acceptHeader = c.req.header('Accept');
 
   try {

--- a/apps/api/src/services/transform.service.ts
+++ b/apps/api/src/services/transform.service.ts
@@ -23,7 +23,7 @@ import { TRANSFORMATION_PRIORITY } from '../utils/video/config';
 // Types for the service
 export interface TransformRequest {
   path: string;
-  userAgent?: string;
+  userAgent: string;
   acceptHeader?: string;
   context: Context;
 }
@@ -245,9 +245,9 @@ export class TransformService {
     localPath: string,
     ext: string | undefined,
     effectiveParams: any,
+    cachePath: string,
     userAgent?: string,
-    acceptHeader?: string,
-    cachePath?: string
+    acceptHeader?: string
   ): Promise<TransformResult> {
     // Prepare source file
     const sourcePath = await prepareSourceFile(
@@ -366,7 +366,7 @@ export class TransformService {
     sourcePath: string,
     params: any,
     filePath: string,
-    cachePath?: string,
+    cachePath: string,
     isTempFile?: boolean
   ): Promise<TransformResult> {
     // Check if this is a thumbnail extraction
@@ -404,7 +404,7 @@ export class TransformService {
     sourcePath: string,
     params: any,
     filePath: string,
-    cachePath?: string,
+    cachePath: string,
     isTempFile?: boolean
   ): Promise<TransformResult> {
     // Check if already being processed

--- a/apps/api/src/services/transform.service.ts
+++ b/apps/api/src/services/transform.service.ts
@@ -1,0 +1,583 @@
+import { Context } from 'hono';
+import { getCachePath, existsInCache, deleteCachedFiles } from '../utils/cache';
+import { parseParams } from '../utils/parser';
+import { createStorageClient } from '../utils/storage/index';
+import { Compression } from '../utils/image/compression';
+import logger from '../utils/logger';
+import { videoJobQueue } from '../utils/video-job-queue';
+import { updateJobStatus } from '../utils/video/queue-db';
+import { readFile } from 'fs/promises';
+import {
+  checkCloudCache,
+  checkLocalCache,
+  verifyFileExists,
+  prepareSourceFile,
+  processImage,
+  processVideo,
+  saveToCaches,
+  cleanupTempFile,
+  performPeriodicCacheCleanup,
+} from '../routes/transform-helpers';
+import { TRANSFORMATION_PRIORITY } from '../utils/video/config';
+
+// Types for the service
+export interface TransformRequest {
+  path: string;
+  userAgent?: string;
+  acceptHeader?: string;
+  context: Context;
+}
+
+export interface TransformResult {
+  buffer: Buffer;
+  contentType: string;
+  headers: Record<string, string>;
+  isProcessing?: boolean;
+  optimizationResult?: any;
+}
+
+export interface CacheCheckResult {
+  cloudCacheBuffer?: Buffer;
+  localCacheBuffer?: Buffer;
+  cachePath?: string;
+  effectiveParams: any;
+}
+
+export class TransformService {
+  private storage: any;
+  private compression: Compression;
+
+  constructor() {
+    this.storage = createStorageClient();
+    this.compression = new Compression();
+  }
+
+  /**
+   * Main transformation method that handles the complete flow
+   */
+  async transform(request: TransformRequest): Promise<TransformResult> {
+    const { path, userAgent, acceptHeader } = request;
+
+    try {
+      // Parse path and parameters
+      const segments = path.split('/').slice(2); // Remove '/t' prefix
+      const params = parseParams(path);
+
+      // Determine file path segments
+      const hasTransform = this.hasTransformSegment(segments);
+      const fileSegments = hasTransform ? segments.slice(1) : segments;
+      const filePath = fileSegments.join('/');
+      const localPath = `./public/${filePath}`;
+      const ext = filePath.split('.').pop();
+
+      // Get effective parameters with format optimization
+      const { effectiveParams, cachePath } =
+        await this.getEffectiveParamsAndCachePath(
+          path,
+          params,
+          userAgent,
+          acceptHeader
+        );
+
+      // Verify original file exists
+      const fileCheck = await verifyFileExists(
+        this.storage,
+        filePath,
+        localPath
+      );
+      if (!fileCheck.exists) {
+        await this.handleFileNotFound(filePath);
+        throw new Error(fileCheck.error || 'File not found');
+      }
+
+      // Check caches
+      const cacheResult = await this.checkCaches(
+        this.storage,
+        filePath,
+        effectiveParams,
+        cachePath
+      );
+
+      if (cacheResult.cloudCacheBuffer) {
+        return this.formatCacheResponse(
+          cacheResult.cloudCacheBuffer,
+          effectiveParams,
+          ext,
+          'cloud'
+        );
+      }
+
+      if (cacheResult.localCacheBuffer) {
+        return this.formatCacheResponse(
+          cacheResult.localCacheBuffer,
+          effectiveParams,
+          ext,
+          'local'
+        );
+      }
+
+      // Process the file
+      return await this.processFile(
+        filePath,
+        localPath,
+        ext,
+        effectiveParams,
+        userAgent,
+        acceptHeader,
+        cachePath
+      );
+    } catch (error) {
+      return this.handleTransformationError(error, request);
+    }
+  }
+
+  /**
+   * Check if the first segment is a transformation string
+   */
+  private hasTransformSegment(segments: string[]): boolean {
+    return (
+      segments.length > 0 &&
+      !segments[0].includes('.') &&
+      (segments[0].includes(',') || segments[0].includes('_'))
+    );
+  }
+
+  /**
+   * Get effective parameters with format optimization and cache path
+   */
+  private async getEffectiveParamsAndCachePath(
+    path: string,
+    params: any,
+    userAgent?: string,
+    acceptHeader?: string
+  ): Promise<{ effectiveParams: any; cachePath: string }> {
+    const ext = path.split('.').pop();
+    let effectiveParams = { ...params };
+    let cachePath = getCachePath(path);
+
+    // Determine optimal format if not explicitly specified
+    if (!params.format && ext?.match(/jpe?g|png|webp|avif|gif/)) {
+      const optimalFormat = this.compression.determineOptimalFormatForCache(
+        userAgent,
+        acceptHeader,
+        ext
+      );
+      effectiveParams = { ...params, format: optimalFormat };
+
+      // Update cache path to include the optimal format
+      const pathWithFormat = path.replace(
+        /\/t\/(.*)$/,
+        `/t/format:${optimalFormat}/$1`
+      );
+      cachePath = getCachePath(pathWithFormat);
+    }
+
+    return { effectiveParams, cachePath };
+  }
+
+  /**
+   * Check both cloud and local caches
+   */
+  private async checkCaches(
+    storage: any,
+    filePath: string,
+    effectiveParams: any,
+    cachePath: string
+  ): Promise<CacheCheckResult> {
+    const result: CacheCheckResult = {
+      effectiveParams,
+      cachePath,
+    };
+
+    // Check cloud cache first
+    const cloudCacheBuffer = await checkCloudCache(
+      storage,
+      filePath,
+      effectiveParams
+    );
+    if (cloudCacheBuffer) {
+      result.cloudCacheBuffer = cloudCacheBuffer;
+      return result;
+    }
+
+    // Check local cache
+    const localCacheBuffer = await checkLocalCache(cachePath);
+    if (localCacheBuffer) {
+      result.localCacheBuffer = localCacheBuffer;
+    }
+
+    return result;
+  }
+
+  /**
+   * Format response for cached content
+   */
+  private formatCacheResponse(
+    buffer: Buffer,
+    effectiveParams: any,
+    ext: string | undefined,
+    _cacheType: 'cloud' | 'local'
+  ): TransformResult {
+    const headers: Record<string, string> = {
+      'Cache-Control': 'public, max-age=31536000, must-revalidate',
+      ETag: `"${JSON.stringify(effectiveParams)}"`,
+      'Content-Length': buffer.length.toString(),
+    };
+
+    // For videos, add video-specific headers
+    if (ext?.match(/mp4|mov|webm/)) {
+      headers['X-Video-Status'] = 'ready';
+    }
+
+    return {
+      buffer,
+      contentType: '', // Will be determined by the route handler
+      headers,
+      isProcessing: false,
+    };
+  }
+
+  /**
+   * Process the file (images and videos)
+   */
+  private async processFile(
+    filePath: string,
+    localPath: string,
+    ext: string | undefined,
+    effectiveParams: any,
+    userAgent?: string,
+    acceptHeader?: string,
+    cachePath?: string
+  ): Promise<TransformResult> {
+    // Prepare source file
+    const sourcePath = await prepareSourceFile(
+      this.storage,
+      filePath,
+      localPath
+    );
+    const isTempFile = !!this.storage;
+
+    try {
+      let buffer: Buffer;
+      let contentType: string;
+      let optimizationResult: any;
+
+      // Process based on file type
+      if (ext?.match(/jpe?g|png|webp|avif|gif/)) {
+        const result = await this.processImageFile(
+          sourcePath,
+          effectiveParams,
+          userAgent,
+          acceptHeader
+        );
+        buffer = result.buffer;
+        contentType = result.contentType;
+        optimizationResult = result.optimizationResult;
+      } else if (ext?.match(/mp4|mov|webm/)) {
+        const result = await this.processVideoFile(
+          sourcePath,
+          effectiveParams,
+          filePath,
+          cachePath,
+          sourcePath !== localPath
+        );
+        return result; // Video processing returns immediately
+      } else {
+        throw new Error('Unsupported file type');
+      }
+
+      // Save to caches
+      if (cachePath) {
+        await saveToCaches(
+          this.storage,
+          filePath,
+          effectiveParams,
+          cachePath,
+          buffer,
+          contentType
+        );
+      }
+
+      // Periodic cache cleanup
+      await performPeriodicCacheCleanup();
+
+      // Format response
+      const headers: Record<string, string> = {
+        'Content-Length': buffer.length.toString(),
+        'Cache-Control': 'public, max-age=31536000, must-revalidate',
+        ETag: `"${filePath}-${JSON.stringify(effectiveParams)}"`,
+      };
+
+      // Add optimization headers if available
+      if (optimizationResult) {
+        headers['X-Original-Size'] = optimizationResult.originalSize.toString();
+        headers['X-Optimized-Size'] =
+          optimizationResult.optimizedSize.toString();
+        headers['X-Compression-Ratio'] =
+          optimizationResult.compressionRatio.toFixed(2);
+        headers['X-Savings-Percent'] = optimizationResult.savings.toFixed(1);
+      }
+
+      // For videos, indicate this is the optimized version
+      if (ext?.match(/mp4|mov|webm/)) {
+        headers['X-Video-Status'] = 'ready';
+      }
+
+      return {
+        buffer,
+        contentType,
+        headers,
+        optimizationResult,
+      };
+    } finally {
+      // Clean up temporary source file if used
+      if (isTempFile) {
+        await cleanupTempFile(sourcePath);
+      }
+    }
+  }
+
+  /**
+   * Process image file
+   */
+  private async processImageFile(
+    sourcePath: string,
+    effectiveParams: any,
+    userAgent?: string,
+    acceptHeader?: string
+  ): Promise<{
+    buffer: Buffer;
+    contentType: string;
+    optimizationResult?: any;
+  }> {
+    return await processImage(
+      sourcePath,
+      effectiveParams,
+      userAgent,
+      acceptHeader,
+      this.compression
+    );
+  }
+
+  /**
+   * Process video file (including job queue management)
+   */
+  private async processVideoFile(
+    sourcePath: string,
+    params: any,
+    filePath: string,
+    cachePath?: string,
+    isTempFile?: boolean
+  ): Promise<TransformResult> {
+    // Check if this is a thumbnail extraction
+    const isThumbnailRequest =
+      params.thumbnail === 'true' || params.thumbnail === '1';
+
+    // For thumbnail extraction: process synchronously
+    if (isThumbnailRequest) {
+      const result = await processVideo(sourcePath, params);
+
+      return {
+        buffer: result.buffer,
+        contentType: result.contentType,
+        headers: {
+          'Content-Length': result.buffer.length.toString(),
+          'Cache-Control': 'public, max-age=31536000, must-revalidate',
+        },
+      };
+    }
+
+    // For video transformations: handle job queue
+    return await this.handleVideoJobQueue(
+      sourcePath,
+      params,
+      filePath,
+      cachePath,
+      isTempFile
+    );
+  }
+
+  /**
+   * Handle video job queue management
+   */
+  private async handleVideoJobQueue(
+    sourcePath: string,
+    params: any,
+    filePath: string,
+    cachePath?: string,
+    isTempFile?: boolean
+  ): Promise<TransformResult> {
+    // Check if already being processed
+    let existingJob = videoJobQueue.getJobByPath(filePath, params);
+    let shouldRequeue = false;
+
+    if (existingJob) {
+      logger.debug(
+        { jobId: existingJob.id, status: existingJob.status },
+        'Video job exists'
+      );
+
+      // If completed, verify cache actually exists before serving
+      if (existingJob.status === 'completed' && cachePath) {
+        const localCacheExists = await existsInCache(cachePath);
+        const cloudCacheExists = this.storage
+          ? await this.storage.exists(filePath, params)
+          : false;
+
+        if (localCacheExists || cloudCacheExists) {
+          // Cache exists, try to serve from local cache first
+          const cachedBuffer = await checkLocalCache(cachePath);
+          if (cachedBuffer) {
+            if (isTempFile) {
+              await cleanupTempFile(sourcePath);
+            }
+
+            return {
+              buffer: cachedBuffer,
+              contentType: `video/${filePath.split('.').pop()}`,
+              headers: {
+                'X-Video-Status': 'ready',
+                'Content-Length': cachedBuffer.length.toString(),
+                'Cache-Control': 'public, max-age=31536000, must-revalidate',
+              },
+            };
+          }
+        } else {
+          // Job is marked as completed but cache doesn't exist
+          logger.warn(
+            { jobId: existingJob.id, filePath, cachePath },
+            'Job marked as completed but cache missing - resetting to pending'
+          );
+          try {
+            updateJobStatus(existingJob.id, 'pending', 0);
+            shouldRequeue = true;
+            existingJob = { ...existingJob, status: 'pending' as const };
+          } catch (error) {
+            logger.error(
+              { error, jobId: existingJob.id },
+              'Failed to reset job status'
+            );
+            shouldRequeue = true;
+          }
+        }
+      }
+    }
+
+    // Add to background processing queue
+    if (
+      !existingJob ||
+      existingJob.status === 'error' ||
+      existingJob.status === 'pending' ||
+      shouldRequeue
+    ) {
+      videoJobQueue
+        .addJob(
+          filePath,
+          params,
+          cachePath,
+          sourcePath,
+          this.storage,
+          TRANSFORMATION_PRIORITY
+        )
+        .catch((error) => {
+          logger.error({ error, filePath }, 'Failed to add video job');
+        });
+    }
+
+    // Return original video immediately
+    try {
+      const originalBuffer = this.storage
+        ? await this.storage.downloadOriginal(filePath)
+        : await readFile(`./public/${filePath}`);
+
+      // Clean up temp file if needed
+      if (isTempFile && sourcePath !== `./public/${filePath}`) {
+        await cleanupTempFile(sourcePath);
+      }
+
+      return {
+        buffer: originalBuffer,
+        contentType: `video/${filePath.split('.').pop()}`,
+        headers: {
+          'X-Video-Status': 'processing',
+          'X-Original-Video': 'true',
+          'Cache-Control': 'public, max-age=0, must-revalidate',
+          ETag: `"${filePath}-processing-${Date.now()}"`,
+          Vary: 'Accept',
+        },
+        isProcessing: true,
+      };
+    } catch (error) {
+      logger.error({ error, filePath }, 'Failed to serve original video');
+      if (isTempFile) {
+        await cleanupTempFile(sourcePath);
+      }
+      throw new Error('Failed to load video');
+    }
+  }
+
+  /**
+   * Handle file not found scenario
+   */
+  private async handleFileNotFound(filePath: string): Promise<void> {
+    try {
+      await deleteCachedFiles(filePath);
+    } catch (error) {
+      logger.warn({ error, filePath }, 'Failed to delete cached files');
+    }
+  }
+
+  /**
+   * Handle transformation errors
+   */
+  private async handleTransformationError(
+    error: any,
+    request: TransformRequest
+  ): Promise<TransformResult> {
+    logger.error({ error, path: request.path }, 'Processing error');
+
+    // Check if this is a "file not found" error from cloud storage
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const isNotFoundError =
+      errorMessage.includes('NoSuchKey') ||
+      errorMessage.includes('NotFound') ||
+      errorMessage.includes('404') ||
+      errorMessage.includes('does not exist') ||
+      errorMessage.includes('not found');
+
+    if (isNotFoundError && this.storage) {
+      // Invalidate cache since the file doesn't exist
+      const pathSegments = request.path.split('/').slice(2);
+      const hasTransform =
+        pathSegments.length > 0 &&
+        !pathSegments[0].includes('.') &&
+        (pathSegments[0].includes(',') || pathSegments[0].includes('_'));
+      const filePath = hasTransform
+        ? pathSegments.slice(1).join('/')
+        : pathSegments.join('/');
+
+      this.storage.invalidateAllCacheEntries(filePath);
+
+      // Delete local cache files
+      try {
+        await deleteCachedFiles(filePath);
+      } catch (cleanupError) {
+        logger.warn(
+          { error: cleanupError, filePath },
+          'Failed to cleanup cache after not found error'
+        );
+      }
+    }
+
+    // Return error result (route handler will convert to appropriate HTTP response)
+    return {
+      buffer: Buffer.from(`Processing failed: ${errorMessage}`),
+      contentType: 'text/plain',
+      headers: {
+        'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+        Pragma: 'no-cache',
+        Expires: '0',
+      },
+    };
+  }
+}


### PR DESCRIPTION
In this PR, I designed an authenticated route that allows to generate signed delivery URLs, as described in #12.

### Usage

```
GET /authenticated/s--{signature}/{transformations}/{filePath}
```

### Signature Generation

To generate a valid signature:

1. Create the string to sign: `{transformations}/{filePath}{API_SECRET}`
2. Compute SHA-1 hash of the string
3. Take the **first 8 characters** of the hex hash

### Example

If:

- API_SECRET = `mysecretkey`
- Transformations = `c_fill,w_300,h_250`
- File path = `sample-authenticated.png`

Then:

- String to sign: `c_fill,w_300,h_250/sample-authenticated.pngmysecretkey`
- SHA-1 hash: `78defdb78bf85...` (first 8 chars: `78defdb7`)
- Final URL: `/authenticated/s--78defdb7/c_fill,w_300,h_250/sample-authenticated.png`

This gurantees secure access to transformations, same transformation capabilities as the public route and protection against unauthorized access. 

### Environment Setup

1. Set the `API_SECRET` environment variable:

   ```bash
   API_SECRET=your-secret-key-here
   ```

2. The authenticated route will validate all requests against this secret

If no API_SECRET is provided, the server will return a 500 error

### Changes made to the codebase:

To ensure the `/t` and the `/authenticated/` endpoints return the same result, I had to separate the logic from the `/t` endpoint into a separate service at `apps/api/src/services/transform.service.ts`. This service is used by both the `/t` and `/authenticated`, giving the same results for the transformations.

# Next steps:
Although the `/authenticated` endpoint works now, we need a way to make media private. I would suggest to create a `type: authenticated` parameter in the `/upload` route and store files with this parameter into a `/a/` folder.

Example:

Upload a file:
```bash
POST /upload
files     image.png
type    authenticated
```

Response from the server:

```json
{
	"success": true,
	"files": [
		{
			"filename": "image.png",
			"path": "/a/image.png",
			"size": 378354,
			"type": "authenticated",
			"url": "/authorized/s--3593cd3a/image.png" # Returns delivery URL without transformations
		}
	]
}
```

Files in the `/a/` folder would not be accessible from the public `/t/` route