### PR TITLE
feat: add multi-architecture Docker support for ARM64

### DIFF
--- a/.github/workflows/basebuild.yml
+++ b/.github/workflows/basebuild.yml
@@ -111,6 +111,7 @@ jobs:
         with:
           context: .
           file: ./docker/full.Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.IMAGE_FULL }}:${{ needs.determine-version.outputs.version }}
@@ -145,6 +146,7 @@ jobs:
         with:
           context: .
           file: ./docker/api.Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.IMAGE_API }}:${{ needs.determine-version.outputs.version }}
@@ -216,8 +218,8 @@ jobs:
             echo ""
             
             echo "### Images Built"
-            echo "- Full stack image"
-            echo "- API-only image"
+            echo "- Full stack image (linux/amd64, linux/arm64)"
+            echo "- API-only image (linux/amd64, linux/arm64)"
             echo ""
             
             if [ "${{ needs.determine-version.outputs.is_release }}" == "true" ]; then


### PR DESCRIPTION
## Summary

- Add multi-architecture build support to Docker images (linux/amd64 + linux/arm64)
- Enables running Openinary on ARM64 devices like Raspberry Pi and Apple Silicon

## Changes

Added `platforms: linux/amd64,linux/arm64` to both Docker build jobs in the CI workflow. This is a minimal change that allows the same Docker images to run on:

- **x86_64/AMD64**: Traditional servers, Intel/AMD processors
- **ARM64/aarch64**: Raspberry Pi, Apple Silicon, AWS Graviton

All dependencies (Node.js, FFmpeg, Nginx, SQLite) already support ARM64 natively.

## Test plan

- [ ] CI workflow builds successfully for both architectures
- [ ] Verify `docker manifest inspect openinary/openinary:latest` shows both `amd64` and `arm64`
- [ ] Test deployment on ARM64 device (Raspberry Pi)