### PR TITLE
fix: Prevent race condition in concurrent image transformation temp files 

### DIFF
--- a/apps/api/src/routes/transform-helpers.ts
+++ b/apps/api/src/routes/transform-helpers.ts
@@ -232,7 +232,10 @@ export async function prepareSourceFile(
     if (!fs.existsSync(tempDir)) {
       fs.mkdirSync(tempDir, { recursive: true });
     }
-    const tempPath = path.join(tempDir, path.basename(filePath));
+    const tempPath = path.join(
+      tempDir,
+      `${crypto.randomUUID()}-${path.basename(filePath)}`,
+    );
     fs.writeFileSync(tempPath, sourceBuffer);
     return tempPath;
   } else {
@@ -256,7 +259,7 @@ export async function processImage(
 
   // Temporary save for advanced optimization
   const fs = await import("fs");
-  const tempOptimPath = originalPath + ".temp";
+  const tempOptimPath = originalPath + `.${crypto.randomUUID()}.temp`;
   fs.writeFileSync(tempOptimPath, basicBuffer);
 
   try {


### PR DESCRIPTION
## Summary                                                                               
                                                                                          
  Concurrent requests processing the same source image intermittently fail with `pngload`: 
  `libspng` read error or unable to open for read errors due to deterministic temp file     
  naming causing file collisions.                                                       
                                                                                          
  ### Problem                                                                               

  Temp file paths are constructed using only the source file's basename, meaning two      
  concurrent requests for the same image resolve to the exact same temp file path. This
  creates a race condition where:                                                         
                                                                                        
  1. Request A downloads the source to /tmp/image.png                                     
  2. Request B overwrites or deletes /tmp/image.png while Request A is still reading it
  3. Request A fails with a corrupted read or missing file error                          
                                                                                          
  The same issue exists in the optimization step, where originalPath + ".temp" produces   
  identical paths for concurrent optimization of the same source.                         
                                                                                          
 ### Fix                                                                                   

  Prefix temp file names with crypto.randomUUID() to guarantee uniqueness per request:    
   
  - `prepareSourceFile()` — path.basename(filePath) →                                       
  `${crypto.randomUUID()}-${path.basename(filePath)}`                                   
  - `processImage()` — originalPath + ".temp" → originalPath +                              
  `.${crypto.randomUUID()}.temp`                                                          