### PR TITLE
Feat/psd support

### DIFF
--- a/.github/skills/issue-fixer/SKILL.md
+++ b/.github/skills/issue-fixer/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: issue-fixer
+description: "Implement GitHub issues collaboratively in open-source repositories with explicit approval gates, incremental delivery, atomic commits, and PR-ready validation. Use when working issue-by-issue with a human operator who decides scope and product direction."
+argument-hint: "Issue URL or description, target branch policy, and any non-negotiable constraints"
+user-invocable: true
+disable-model-invocation: false
+---
+
+# Open Source Issue Implementation
+
+## Outcome
+
+Produce a production-ready issue implementation with:
+
+- Shared understanding of scope and constraints
+- Operator-approved technical approach before coding
+- Incremental, reviewable changes
+- Clean commit history
+- Verified build/lint/type/tests status
+- PR-ready summary linked to the issue
+
+## When to Use
+
+Use this skill when:
+
+- Working on a single GitHub issue in an open-source repository
+- A human operator must validate decisions before implementation advances
+- Scope control and traceable collaboration matter more than speed
+
+Do not use this skill when:
+
+- Doing broad discovery without a concrete issue
+- Running large autonomous refactors without operator checkpoints
+
+## Collaboration Contract
+
+At all times:
+
+- Propose -> operator decides -> implement
+- Do not make product decisions alone
+- Do not expand scope without explicit approval
+- Prefer clarity over speed
+- Ask concise clarification questions when ambiguous
+
+## Required Inputs
+
+Collect or confirm:
+
+- Issue link or full issue text
+- Target base branch and contribution conventions
+- Definition of done (tests, lint/type, docs, screenshots, changelog)
+- Constraints (backward compatibility, performance, API stability)
+
+## Procedure
+
+### 1. Repository Sync
+
+Run and report results:
+
+1. `git checkout main`
+2. `git pull origin main`
+3. `git fetch --all`
+4. `git status`
+
+Validation checks:
+
+- Working tree is clean (or operator explicitly approves proceeding with local changes)
+- `main` is current
+- No unresolved conflicts
+
+If validation fails:
+
+- Stop and ask the operator how to proceed before editing code
+
+### 2. Issue Analysis (No Coding)
+
+Deliver a concise analysis containing:
+
+- 2-3 sentence summary
+- Goal
+- In-scope items
+- Out-of-scope items
+- Constraints
+- Edge cases
+- Open questions
+
+Decision gate:
+
+- Wait for operator validation before moving forward
+
+### 3. Solution Proposal (No Coding)
+
+Propose implementation details:
+
+- Technical approach
+- Impacted files/modules
+- Data flow (if relevant)
+- Risks and trade-offs
+- Test strategy
+
+Decision gate:
+
+- Wait for explicit operator approval before coding
+
+### 4. Branch Creation
+
+Create a branch only after proposal approval:
+
+1. Choose one prefix: `feat/`, `fix/`, `refactor/`, or `chore/`
+2. Create branch: `git checkout -b <prefix><short-description>`
+
+### 5. Implementation Loop (Incremental)
+
+For each iteration:
+
+1. Explain the next small step
+2. Implement that step
+3. Report what changed and why
+4. Ask for operator validation
+
+Suggested iteration order:
+
+- Setup/refactor prerequisites
+- Core functionality
+- Edge cases and error handling
+- Cleanup and documentation
+
+Rules:
+
+- Keep diffs focused and reviewable
+- Avoid unrelated file churn
+- Halt when requirements become ambiguous
+
+### 6. Atomic Commits
+
+Commit each logical unit separately using conventional commits, for example:
+
+- `feat: add overlay support`
+- `fix: handle empty queue payload`
+
+Commit quality checks:
+
+- One logical change per commit
+- Message reflects actual change
+- No debug artifacts
+
+### 7. Validation Before PR
+
+Run or confirm:
+
+- Build succeeds
+- Lint/type checks pass
+- Tests pass (or clearly state missing tests and rationale)
+- No debug code, temporary logging, or dead code remains
+
+If checks fail:
+
+- Fix failures or escalate with a concise blocker report
+
+### 8. Sync Before Push
+
+Before opening PR:
+
+1. `git fetch origin`
+2. `git rebase origin/main`
+
+If conflicts appear:
+
+- Resolve cleanly
+- Re-run validation checks
+- Summarize conflict decisions for operator visibility
+
+### 9. Pull Request Preparation
+
+Create a structured PR description containing:
+
+- Problem summary
+- Solution summary
+- Key implementation details
+- Validation evidence (build/lint/type/tests)
+- Visuals/screenshots when relevant
+- Linked issue
+
+### 10. Post-Merge Cleanup
+
+After merge confirmation:
+
+1. `git branch -d <branch>`
+2. `git push origin --delete <branch>`
+
+## Completion Criteria
+
+This skill is complete when:
+
+- Issue scope is implemented as approved
+- Operator accepted each decision gate
+- Validation checks are green (or exceptions documented and accepted)
+- PR is ready or merged with cleanup completed
+
+## Message Format (Recommended)
+
+For each operator-facing update, use:
+
+1. Intent
+2. Action taken
+3. Result
+4. Decision needed
+
+Keep updates concise and structured.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "@aws-sdk/s3-request-presigner": "^3.855.0",
     "@hono/node-server": "^1.8.0",
     "@hono/zod-validator": "^0.7.4",
+    "@webtoon/psd": "^0.4.0",
     "better-sqlite3": "^11.8.1",
     "dotenv": "^17.2.1",
     "fluent-ffmpeg": "^2.1.2",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import transform from "./routes/transform";
 import authenticated from "./routes/authenticated";
 import upload from "./routes/upload";
 import storageRoute from "./routes/storage";
+import download from "./routes/download";
 import apiKeys from "./routes/api-keys";
 import health from "./routes/health";
 import videoStatus from "./routes/video-status";
@@ -73,6 +74,11 @@ app.route("/video-status", videoStatus);
 app.use("/t", publicRateLimit);
 app.use("/t/*", publicRateLimit);
 app.route("/t", transform);
+
+// Original file download route (public — consistent with /t/)
+app.use("/download", publicRateLimit);
+app.use("/download/*", publicRateLimit);
+app.route("/download", download);
 
 // Authenticated image transformation route (with signature verification)
 app.use("/authenticated", publicRateLimit);

--- a/apps/api/src/routes/download.ts
+++ b/apps/api/src/routes/download.ts
@@ -1,0 +1,89 @@
+import { Hono } from "hono";
+import { createStorageClient } from "../utils/storage/index";
+import fs from "fs";
+import path from "path";
+import logger, { serializeError } from "../utils/logger";
+
+const download = new Hono();
+const storage = createStorageClient();
+
+/**
+ * GET /download/:path
+ * Serves the original stored file as an attachment (no transformation applied).
+ * Public route — consistent with /t/* which is also public.
+ */
+download.get("/*", async (c) => {
+  const requestPath = c.req.path;
+
+  // Strip leading /download/ prefix
+  const rawFilePath = requestPath.replace(/^\/download\/?/, "");
+
+  if (!rawFilePath) {
+    return c.text("File path is required", 400);
+  }
+
+  // Decode and sanitise path (prevent directory traversal)
+  let filePath: string;
+  try {
+    filePath = decodeURIComponent(rawFilePath)
+      .replace(/\.\./g, "")
+      .replace(/\\/g, "/")
+      .replace(/\/+/g, "/")
+      .replace(/^\/+/, "");
+  } catch {
+    return c.text("Invalid file path", 400);
+  }
+
+  if (!filePath) {
+    return c.text("Invalid file path", 400);
+  }
+
+  const filename = path.basename(filePath);
+
+  try {
+    let buffer: Buffer;
+
+    if (storage) {
+      // Cloud storage
+      try {
+        buffer = await storage.downloadOriginal(filePath);
+      } catch {
+        return c.text("File not found", 404);
+      }
+    } else {
+      // Local storage
+      const localPath = path.join("./public", filePath);
+      if (!fs.existsSync(localPath) || fs.statSync(localPath).isDirectory()) {
+        return c.text("File not found", 404);
+      }
+      buffer = fs.readFileSync(localPath);
+    }
+
+    // Derive a safe Content-Type from the extension
+    const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+    const contentTypeMap: Record<string, string> = {
+      jpg: "image/jpeg",
+      jpeg: "image/jpeg",
+      png: "image/png",
+      webp: "image/webp",
+      avif: "image/avif",
+      gif: "image/gif",
+      psd: "image/vnd.adobe.photoshop",
+      mp4: "video/mp4",
+      mov: "video/quicktime",
+      webm: "video/webm",
+    };
+    const contentType = contentTypeMap[ext] ?? "application/octet-stream";
+
+    c.header("Content-Type", contentType);
+    c.header("Content-Disposition", `attachment; filename="${encodeURIComponent(filename)}"`);
+    c.header("Content-Length", buffer.length.toString());
+    c.header("Cache-Control", "private, no-store");
+    return c.body(new Uint8Array(buffer));
+  } catch (error) {
+    logger.error({ error: serializeError(error), filePath }, "Download failed");
+    return c.text("Internal server error", 500);
+  }
+});
+
+export default download;

--- a/apps/api/src/routes/transform-helpers.ts
+++ b/apps/api/src/routes/transform-helpers.ts
@@ -295,6 +295,8 @@ export async function processImage(
       contentType = "image/avif";
     } else if (ext?.match(/gif/)) {
       contentType = "image/gif";
+    } else if (ext?.match(/psd/)) {
+      contentType = "image/png"; // PSD is decoded to PNG before Sharp processing
     }
 
     // Cleanup in case of error

--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -32,6 +32,8 @@ const ALLOWED_TYPES = {
   "image/gif": [".gif"],
   "image/heic" : ['.heic', '.heif'],
   "image/heif" : ['.heic', '.heif'],
+  "image/vnd.adobe.photoshop": [".psd"],
+  "application/octet-stream": [".psd"],
   // Videos
   "video/mp4": [".mp4"],
   "video/quicktime": [".mov"],
@@ -443,7 +445,7 @@ upload.post("/", async (c) => {
       if (!validateFileType(filename, mimeType)) {
         failedUploads.push({
           filename: rawSanitizedPath,
-          error: `Invalid file type: ${mimeType}. Allowed types: images (jpg, jpeg, png, webp, avif, gif, heic, heif) and videos (mp4, mov, webm)`,
+          error: `Invalid file type: ${mimeType}. Allowed types: images (jpg, jpeg, png, webp, avif, gif, heic, heif, psd) and videos (mp4, mov, webm)`,
         });
         continue;
       }

--- a/apps/api/src/services/transform.service.ts
+++ b/apps/api/src/services/transform.service.ts
@@ -156,7 +156,7 @@ export class TransformService {
     let cachePath = getCachePath(path);
 
     // Determine optimal format if not explicitly specified
-    if (!params.format && ext?.match(/jpe?g|png|webp|avif|gif/)) {
+    if (!params.format && ext?.match(/jpe?g|png|webp|avif|gif|psd/)) {
       const optimalFormat = this.compression.determineOptimalFormatForCache(
         userAgent,
         acceptHeader,
@@ -263,7 +263,7 @@ export class TransformService {
       let optimizationResult: any;
 
       // Process based on file type
-      if (ext?.match(/jpe?g|png|webp|avif|gif/)) {
+      if (ext?.match(/jpe?g|png|webp|avif|gif|psd/)) {
         const result = await this.processImageFile(
           sourcePath,
           effectiveParams,

--- a/apps/api/src/utils/image/index.ts
+++ b/apps/api/src/utils/image/index.ts
@@ -1,10 +1,30 @@
 import sharp from 'sharp';
+import { readFile } from 'fs/promises';
+import Psd from '@webtoon/psd';
 import { TransformParams } from 'shared';
 import { applyAspectRatio } from './aspect-ratio';
 import { applyResize } from './resize';
 import { applyRotation } from './rotation';
 import { applyQuality } from './quality';
 import { applyResizeComposite } from './param-registry';
+
+/**
+ * Decode a PSD file into a Sharp instance via raw RGBA pixel data.
+ * Sharp cannot read PSD natively; @webtoon/psd composites all layers first.
+ * The output is encoded as PNG so the temp-file step in processImage can read it.
+ */
+async function decodePsd(inputPath: string): Promise<sharp.Sharp> {
+  const fileBuffer = await readFile(inputPath);
+  const arrayBuffer = fileBuffer.buffer.slice(
+    fileBuffer.byteOffset,
+    fileBuffer.byteOffset + fileBuffer.byteLength
+  ) as ArrayBuffer;
+  const psd = Psd.parse(arrayBuffer);
+  const pixelData = await psd.composite();
+  return sharp(Buffer.from(pixelData), {
+    raw: { width: psd.width, height: psd.height, channels: 4 },
+  }).png();
+}
 
 // Re-export types for backward compatibility
 export * from './types';
@@ -14,7 +34,9 @@ export * from './param-registry';
  * Transform an image with the specified parameters
  */
 export const transformImage = async (inputPath: string, params: TransformParams): Promise<Buffer> => {
-  let image = sharp(inputPath);
+  let image = inputPath.toLowerCase().endsWith('.psd')
+    ? await decodePsd(inputPath)
+    : sharp(inputPath);
 
   // Convert TransformParams to a record for easier access
   const paramsRecord: Record<string, string> = {

--- a/apps/api/src/utils/video/format.ts
+++ b/apps/api/src/utils/video/format.ts
@@ -1,7 +1,7 @@
 /**
  * Supported image formats for video thumbnails
  */
-export const IMAGE_FORMATS = new Set(["jpg", "jpeg", "png", "webp", "avif", "gif"]);
+export const IMAGE_FORMATS = new Set(["jpg", "jpeg", "png", "webp", "avif", "gif", "psd"]);
 
 /**
  * Supported video formats

--- a/apps/web/src/components/details-sidebar/use-asset-details.ts
+++ b/apps/web/src/components/details-sidebar/use-asset-details.ts
@@ -220,9 +220,17 @@ export function useAssetDetails(onOpenChange?: (open: boolean) => void) {
   }
 
   const handleDownload = () => {
-    if (mediaUrl) {
-      window.open(mediaUrl, "_blank")
-    }
+    if (!asset) return
+    const downloadUrl = `${apiBaseUrl}/download/${asset.path
+      .split("/")
+      .map((s) => encodeURIComponent(s))
+      .join("/")}`
+    const a = document.createElement("a")
+    a.href = downloadUrl
+    a.download = asset.name
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
   }
 
   const handleOpenInNewTab = () => {

--- a/apps/web/src/components/details-sidebar/utils.ts
+++ b/apps/web/src/components/details-sidebar/utils.ts
@@ -16,7 +16,8 @@ export function findAssetInTree(
       lowerName.endsWith(".png") ||
       lowerName.endsWith(".webp") ||
       lowerName.endsWith(".gif") ||
-      lowerName.endsWith(".avif")
+      lowerName.endsWith(".avif") ||
+      lowerName.endsWith(".psd")
 
     const isVideo =
       lowerName.endsWith(".mp4") ||

--- a/apps/web/src/components/media-grid.tsx
+++ b/apps/web/src/components/media-grid.tsx
@@ -74,7 +74,8 @@ function findItemsInPath(
         lowerName.endsWith(".png") ||
         lowerName.endsWith(".webp") ||
         lowerName.endsWith(".gif") ||
-        lowerName.endsWith(".avif");
+        lowerName.endsWith(".avif") ||
+        lowerName.endsWith(".psd");
 
       const isVideo =
         lowerName.endsWith(".mp4") ||

--- a/apps/web/src/components/upload-section.tsx
+++ b/apps/web/src/components/upload-section.tsx
@@ -49,7 +49,7 @@ export function UploadSection({ uploadToFolder }: { uploadToFolder?: string }) {
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     accept: {
-      "image/*": [".jpg", ".jpeg", ".png", ".webp", ".avif", ".gif"],
+      "image/*": [".jpg", ".jpeg", ".png", ".webp", ".avif", ".gif", ".psd"],
       "video/*": [".mp4", ".mov", ".webm"],
     },
   });
@@ -165,7 +165,7 @@ export function UploadSection({ uploadToFolder }: { uploadToFolder?: string }) {
                   Drop files here, or click to select files
                 </p>
                 <p className="text-sm text-muted-foreground">
-                  Supports: JPG, PNG, WebP, AVIF, GIF, MP4, MOV, WebM
+                  Supports: JPG, PNG, WebP, AVIF, GIF, PSD, MP4, MOV, WebM
                 </p>
                 <div className="flex gap-2 mt-2">
                   <Button

--- a/apps/web/src/hooks/use-storage-tree.ts
+++ b/apps/web/src/hooks/use-storage-tree.ts
@@ -42,7 +42,8 @@ async function fetchStorageTree(): Promise<TreeDataItem[]> {
         lowerName.endsWith(".png") ||
         lowerName.endsWith(".webp") ||
         lowerName.endsWith(".gif") ||
-        lowerName.endsWith(".avif")
+        lowerName.endsWith(".avif") ||
+        lowerName.endsWith(".psd")
       ) {
         icon = FileImage;
       } else if (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@hono/zod-validator':
         specifier: ^0.7.4
         version: 0.7.4(hono@4.10.7)(zod@4.1.12)
+      '@webtoon/psd':
+        specifier: ^0.4.0
+        version: 0.4.0
       better-sqlite3:
         specifier: ^11.8.1
         version: 11.10.0
@@ -2486,6 +2489,9 @@ packages:
   '@webgpu/types@0.1.66':
     resolution: {integrity: sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA==}
 
+  '@webtoon/psd@0.4.0':
+    resolution: {integrity: sha512-ztriE8oFOamRrV9opBURDy+JMiyhur2//vOXsC5CgdnYCB0L1Lnaag4NzP8N+NFCj7uNz9JRYtPmAbQMSDLIsQ==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -4148,6 +4154,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -7397,6 +7404,8 @@ snapshots:
 
   '@webgpu/types@0.1.66': {}
 
+  '@webtoon/psd@0.4.0': {}
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -8053,7 +8062,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.32.0(jiti@2.6.1)))(eslint@9.32.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -8075,7 +8084,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.32.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.32.0(jiti@2.6.1)))(eslint@9.32.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
Closes #20

## What
Allow `.psd` files to be uploaded and converted on-the-fly to JPEG, WebP, AVIF, or PNG via the existing transform pipeline (`f_jpeg`, `f_webp`, etc.). PSD files are stored as-is and processed by Sharp on demand — no forced conversion at upload time.

## Changes
- **API:** added `image/vnd.adobe.photoshop` + `application/octet-stream` (browser fallback) to `ALLOWED_TYPES`; extended image format regex and `IMAGE_FORMATS` to route PSD through Sharp
- **Web:** `.psd` accepted in the upload dropzone; recognized as an image in the media grid, storage tree, and details sidebar

## Notes
- PSD layers are flattened by Sharp (expected)
- Alpha channel is flattened to white on JPEG output