### PR TITLE
docs: added CORS_ORIGIN

### DIFF
--- a/docker.env.example
+++ b/docker.env.example
@@ -35,6 +35,13 @@ BETTER_AUTH_URL=http://localhost:3000
 # BETTER_AUTH_INTERNAL_URL=http://127.0.0.1:3001
 
 # ============================================
+# Accessibility (Optional)
+# ============================================
+# If you want to use openinary from within another
+# website, then you need to configure the allowed CORS origin.
+# CORS_ORIGIN=https://yourwebsite.com
+
+# ============================================
 # API Configuration (Full Stack)
 # ============================================
 NEXT_PUBLIC_API_BASE_URL=/api


### PR DESCRIPTION
So, I had the problem, that I tried to access openinary from within my website. It failed. Hence I read through the docs page, but I found even in the server section no way to configure a third-party website, from where I want to access openinary. After many tries I asked ChatGPT. It added a parameter, which was not documented anywhere. But it worked. From there on I could access openinary (API) from within my website. Hence this Pull-Request, to help others with the same issue. Because the env var seems to be used from whichever library within the code, I added only the docs, that this variable exists