### PR TITLE
fix(api): prevent folder names with underscores from being misidentified as transform segments

### DIFF
--- a/apps/api/src/routes/authenticated.ts
+++ b/apps/api/src/routes/authenticated.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { TransformService } from '../services/transform.service';
 import logger, { serializeError } from '../utils/logger';
 import { verifySignature, SIGNATURE_LENGTH, sanitizeFilePath } from '../utils/signature';
+import { isTransformSegment } from '../utils/parser';
 
 const t = new Hono();
 const transformService = new TransformService();
@@ -46,9 +47,7 @@ t.get('/*', async (c) => {
     // Determine transformation string and file path
     // Format: {transformations}/{route}
     const hasTransform =
-      routeSegments.length > 0 &&
-      !routeSegments[0].includes('.') &&
-      (routeSegments[0].includes(',') || routeSegments[0].includes('_'));
+      routeSegments.length > 0 && isTransformSegment(routeSegments[0]);
 
     const transformations = hasTransform ? routeSegments[0] : '';
     const filePathSegments = hasTransform
@@ -161,3 +160,4 @@ t.get('/*', async (c) => {
 });
 
 export default t;
+

--- a/apps/api/src/services/transform.service.ts
+++ b/apps/api/src/services/transform.service.ts
@@ -1,6 +1,6 @@
 import { Context } from 'hono';
 import { getCachePath, existsInCache, deleteCachedFiles } from '../utils/cache';
-import { parseParams } from '../utils/parser';
+import { parseParams, isTransformSegment } from '../utils/parser';
 import { createStorageClient } from '../utils/storage/index';
 import { Compression } from '../utils/image/compression';
 import logger, { serializeError } from '../utils/logger';
@@ -135,11 +135,7 @@ export class TransformService {
    * Check if the first segment is a transformation string
    */
   private hasTransformSegment(segments: string[]): boolean {
-    return (
-      segments.length > 0 &&
-      !segments[0].includes('.') &&
-      (segments[0].includes(',') || segments[0].includes('_'))
-    );
+    return segments.length > 0 && isTransformSegment(segments[0]);
   }
 
   /**
@@ -555,9 +551,7 @@ export class TransformService {
       // Invalidate cache since the file doesn't exist
       const pathSegments = request.path.split('/').slice(2);
       const hasTransform =
-        pathSegments.length > 0 &&
-        !pathSegments[0].includes('.') &&
-        (pathSegments[0].includes(',') || pathSegments[0].includes('_'));
+        pathSegments.length > 0 && isTransformSegment(pathSegments[0]);
       const filePath = hasTransform
         ? pathSegments.slice(1).join('/')
         : pathSegments.join('/');
@@ -587,3 +581,4 @@ export class TransformService {
     };
   }
 }
+

--- a/apps/api/src/utils/parser.ts
+++ b/apps/api/src/utils/parser.ts
@@ -16,18 +16,45 @@ export const parseParams = (path: string) => {
 };
 
 /**
- * Heuristic check if a path segment looks like a transformation
- * definition (e.g. "w_300,h_300,c_fill").
+ * Valid values for each transformation key.
+ * Used by isTransformSegment to reject folder names that happen to start with a known key.
  */
-const isTransformSegment = (segment: string): boolean => {
-  if (!segment || segment.includes(".")) return false;
-  // Must contain either "," separating options or "_" within an option
-  if (!segment.includes(",") && !segment.includes("_")) return false;
+const TRANSFORM_VALUE_PATTERNS: Readonly<Record<string, RegExp>> = {
+  w:  /^\d+$|^auto$/,
+  h:  /^\d+$|^auto$/,
+  c:  /^(fill|lfill|fill_pad|fit|limit|mfit|scale|crop|thumb|pad|lpad)$/,
+  g:  /^(center|c|north(?:_center)?|n|south(?:_center)?|s|east|e|west|w|faces?(?:_center)?|auto)$/,
+  q:  /^\d+$|^auto$/,
+  f:  /^(webp|jpe?g|png|avif|gif|psd|mp4|webm|mov|avi|mp3|wav|ogg|pdf|auto)$/,
+  a:  /^-?\d+$|^auto$/,
+  ar: /^\d+:\d+$|^\d+(?:\.\d+)?$/,
+  b:  /^(transparent|white|black|rgb:[0-9a-fA-F]{3,8}|#?[0-9a-fA-F]{3,8})$/,
+  bg: /^(transparent|white|black|rgb:[0-9a-fA-F]{3,8}|#?[0-9a-fA-F]{3,8})$/,
+  so: /^\d+(?:\.\d+)?$/,
+  eo: /^\d+(?:\.\d+)?$/,
+  t:  /^(true|1|\d+)$/,
+  tt: /^\d+(?:\.\d+)?$/,
+};
 
-  // Look for known transformation keys
-  // FIX H12: Add t and tt to recognized keys for thumbnail support
-  const hasKnownKey = /(,|^)(w|h|c|g|q|f|a|ar|b|bg|so|eo|t|tt)_/.test("," + segment);
-  return hasKnownKey;
+const isValidTransformPair = (part: string): boolean => {
+  const underscoreIndex = part.indexOf("_");
+  if (underscoreIndex === -1) return false;
+  const key = part.substring(0, underscoreIndex);
+  const value = part.substring(underscoreIndex + 1);
+  if (!value) return false;
+  const pattern = TRANSFORM_VALUE_PATTERNS[key];
+  return pattern !== undefined && pattern.test(value);
+};
+
+/**
+ * Check if a path segment is a transformation definition (e.g. "w_300,h_300,c_fill").
+ * Every comma-separated part must be a valid key_value pair to avoid false positives
+ * on folder names like "w_photos", "f_family", or "bg_images".
+ */
+export const isTransformSegment = (segment: string): boolean => {
+  if (!segment || segment.includes(".")) return false;
+  const parts = segment.split(",").filter(Boolean);
+  return parts.length > 0 && parts.every(isValidTransformPair);
 };
 
 /**
@@ -229,3 +256,4 @@ const mapBackground = (value: string): string => {
       return `#${value}`;
   }
 };
+


### PR DESCRIPTION
- Fixes a bug where directory names containing `_` (e.g. `Pictures_Abc`) caused a 404 when accessing files directly without transformations
- The old heuristic used `_` presence to detect transform segments, which falsely matched folder names like `w_photos` or `bg_images`
- Replaced the heuristic with a strict validator that checks every `key_value` pair against known transform keys and their expected value patterns


Closes #41