### PR TITLE
fix(image): preserve alpha channel when quality param is specified

### DIFF
--- a/apps/api/src/utils/image/compression.ts
+++ b/apps/api/src/utils/image/compression.ts
@@ -31,10 +31,12 @@ export class Compression {
     // If format is explicitly specified, use it directly (no size comparison needed)
     if (params.format) {
       const explicitFormat = params.format === 'jpg' ? 'jpeg' : params.format;
+      const userQuality = params.quality ? parseInt(String(params.quality)) : undefined;
       const optimalQuality = this.calculateOptimalQuality(
-        analysis, 
-        originalSize, 
-        explicitFormat
+        analysis,
+        originalSize,
+        explicitFormat,
+        userQuality
       );
       
       let pipeline = this.preparePipeline(inputPath, analysis, metadata, originalSize);
@@ -109,9 +111,10 @@ export class Compression {
     // Encode in all formats and compare sizes
     const results: Array<{ format: ImageFormat; buffer: Buffer; size: number }> = [];
     
+    const userQuality = params.quality ? parseInt(String(params.quality)) : undefined;
     for (const format of formatsToTest) {
       try {
-        const quality = this.calculateOptimalQuality(analysis, originalSize, format);
+        const quality = this.calculateOptimalQuality(analysis, originalSize, format, userQuality);
         let pipeline = this.preparePipeline(inputPath, analysis, metadata, originalSize);
         pipeline = this.applyFormat(pipeline, format, quality);
         
@@ -130,7 +133,7 @@ export class Compression {
     // Find the smallest format
     if (results.length === 0) {
       // Fallback: use JPEG
-      const quality = this.calculateOptimalQuality(analysis, originalSize, 'jpeg');
+      const quality = this.calculateOptimalQuality(analysis, originalSize, 'jpeg', userQuality);
       let pipeline = this.preparePipeline(inputPath, analysis, metadata, originalSize);
       pipeline = this.applyFormat(pipeline, 'jpeg', quality);
       const buffer = await pipeline.toBuffer();
@@ -305,14 +308,19 @@ export class Compression {
   }
 
   /**
-   * Calculates optimal quality based on content (simplified for speed)
+   * Calculates optimal quality based on content (simplified for speed).
+   * If userQuality is provided, it takes precedence over automatic calculation.
    */
   private calculateOptimalQuality(
     analysis: ImageAnalysis,
     fileSize: number,
-    format: string
+    format: string,
+    userQuality?: number
   ): number {
-    
+    if (userQuality !== undefined && !isNaN(userQuality) && userQuality >= 1 && userQuality <= 100) {
+      return userQuality;
+    }
+
     let baseQuality = 85;
     
     // Simplified format-specific adjustments

--- a/apps/api/src/utils/image/quality.ts
+++ b/apps/api/src/utils/image/quality.ts
@@ -1,17 +1,13 @@
 import sharp from 'sharp';
 
 /**
- * Apply quality settings to an image
+ * Apply quality settings to an image.
+ * Quality is deferred to the final format encoding step in the compression
+ * pipeline to avoid stripping alpha channels via premature JPEG conversion.
  */
 export const applyQuality = (
   image: sharp.Sharp,
-  qualityParam: string | number
+  _qualityParam: string | number
 ): sharp.Sharp => {
-  const quality = typeof qualityParam === 'string' ? parseInt(qualityParam) : qualityParam;
-  
-  if (!isNaN(quality) && quality >= 1 && quality <= 100) {
-    return image.jpeg({ quality });
-  }
-  
   return image;
 };


### PR DESCRIPTION
## Summary

- `applyQuality()` was calling `.jpeg({ quality })` unconditionally, converting the image to JPEG mid-pipeline and stripping the alpha channel before the compression step ran
- The user-supplied quality value (`q_85`, etc.) was also silently ignored — `optimizeForDelivery` used its own internal quality calculation and never read `params.quality`
- Quality is now deferred to `optimizeForDelivery`, which applies it in the correct format-aware encoding step and respects the user value across all code paths (explicit format, format auto-selection, and JPEG fallback)

Fixes #40