### PR TITLE
fixed: fix the issue where loading fails and returns a 500 error when the file name contains Chinese characters.

### DIFF
--- a/apps/api/src/services/transform.service.ts
+++ b/apps/api/src/services/transform.service.ts
@@ -301,7 +301,8 @@ export class TransformService {
       const headers: Record<string, string> = {
         'Content-Length': buffer.length.toString(),
         'Cache-Control': 'public, max-age=31536000, must-revalidate',
-        ETag: `"${filePath}-${JSON.stringify(effectiveParams)}"`,
+        // URL-encode filePath to ensure it only contains ASCII characters for ETag
+        ETag: `"${encodeURIComponent(filePath)}-${JSON.stringify(effectiveParams)}"`,
       };
 
       // Add optimization headers if available
@@ -498,7 +499,8 @@ export class TransformService {
           'X-Video-Status': 'processing',
           'X-Original-Video': 'true',
           'Cache-Control': 'public, max-age=0, must-revalidate',
-          ETag: `"${filePath}-processing-${Date.now()}"`,
+          // URL-encode filePath to ensure it only contains ASCII characters for ETag
+          ETag: `"${encodeURIComponent(filePath)}-processing-${Date.now()}"`,
           Vary: 'Accept',
         },
         isProcessing: true,


### PR DESCRIPTION
Hello. During the use of the project, it was found that files with Chinese characters in their names would fail to load after a 10-second timeout and return a 500 error. After investigation, the issue was traced to abnormal ETag information in the request header.
To resolve this problem, we have added URL encoding processing for file paths in the project to ensure that only ASCII characters are included for correct ETag calculation. This optimization has been fully verified to be effective, and we hereby request to merge the relevant code into the project.