### PR TITLE
fix(video): correct content type for thumbnail and non-mp4 outputs

### DIFF
--- a/apps/api/src/utils/video/format.ts
+++ b/apps/api/src/utils/video/format.ts
@@ -52,3 +52,25 @@ export const determineOutputFormat = (
     isThumbnail,
   };
 };
+
+/**
+ * MIME content type for a resolved output format.
+ */
+const CONTENT_TYPE_BY_FORMAT: Readonly<Record<string, string>> = {
+  jpg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+  avif: "image/avif",
+  gif: "image/gif",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+};
+
+export const contentTypeForFormat = (format: string): string => {
+  const normalized = normalizeFormat(format.toLowerCase());
+  if (CONTENT_TYPE_BY_FORMAT[normalized]) {
+    return CONTENT_TYPE_BY_FORMAT[normalized];
+  }
+  return IMAGE_FORMATS.has(normalized) ? `image/${normalized}` : "video/mp4";
+};

--- a/apps/api/src/utils/video/video-worker.ts
+++ b/apps/api/src/utils/video/video-worker.ts
@@ -12,6 +12,7 @@ import {
   type VideoJob,
 } from "./queue-db";
 import { MAX_CONCURRENT_JOBS, WORKER_POLL_INTERVAL_MS } from "./config";
+import { contentTypeForFormat, determineOutputFormat } from "./format";
 
 export interface WorkerEvents {
   "job:created": (job: VideoJob) => void;
@@ -167,9 +168,9 @@ export class VideoWorker extends EventEmitter {
 
         // Upload to cloud storage if configured
         if (this.storage) {
-          const contentType = params.format === "jpg" || params.format === "png"
-            ? `image/${params.format}`
-            : "video/mp4";
+          const sourceExt = job.file_path.split(".").pop()?.toLowerCase();
+          const { format } = determineOutputFormat(sourceExt, params.format);
+          const contentType = contentTypeForFormat(format);
           await this.storage.upload(job.file_path, params, buffer, contentType);
         }
 


### PR DESCRIPTION
## Summary
- Video thumbnails (`f_webp`, `f_gif`, `f_avif`, `f_jpeg`) were uploaded with `Content-Type: video/mp4` instead of the matching `image/*` type, and `f_jpg` produced an invalid `image/jpg`.
- Non-mp4 video transforms (`webm`, `mov`) were also labeled `video/mp4`.
- The content type is now derived from the **resolved output format** via the existing `determineOutputFormat()`, plus a small `contentTypeForFormat()` helper added next to it in `video/format.ts`.

Note: `job.file_path` is the *source* path, so the previous `params.format`-only check couldn't reliably tell a thumbnail from a video output. `determineOutputFormat(sourceExt, params.format)` already resolves this correctly.

