### PR TITLE
perf(video): process jobs in parallel up to maxConcurrent

### DIFF
--- a/apps/api/src/utils/video/video-worker.ts
+++ b/apps/api/src/utils/video/video-worker.ts
@@ -29,7 +29,7 @@ export class VideoWorker extends EventEmitter {
   private maxConcurrent: number;
   private pollInterval: number;
   private storage: CloudStorage | null;
-  private isProcessing: boolean = false;
+  private isAcquiring: boolean = false;
 
   constructor(storage: CloudStorage | null) {
     super();
@@ -64,13 +64,13 @@ export class VideoWorker extends EventEmitter {
 
     // Start polling for jobs
     this.intervalId = setInterval(() => {
-      this.processNextJob().catch((error) => {
+      this.fillAvailableSlots().catch((error) => {
         logger.error({ error: serializeError(error) }, "Error in worker polling loop");
       });
     }, this.pollInterval);
 
     // Also process immediately on start
-    this.processNextJob().catch((error) => {
+    this.fillAvailableSlots().catch((error) => {
       logger.error({ error: serializeError(error) }, "Error in initial job processing");
     });
   }
@@ -95,125 +95,141 @@ export class VideoWorker extends EventEmitter {
   }
 
   /**
-   * Process the next job in the queue
+   * Fill every free concurrency slot with pending jobs (runs on each poll tick)
    */
-  async processNextJob(): Promise<void> {
-    // Prevent concurrent execution of this method
-    if (this.isProcessing) {
+  async fillAvailableSlots(): Promise<void> {
+    // Serialize acquisition so overlapping ticks don't grab the same job
+    if (this.isAcquiring) {
       return;
     }
 
     try {
-      this.isProcessing = true;
+      this.isAcquiring = true;
 
-      // Check if we can process more jobs
-      const processingCount = countProcessingJobs();
-      if (processingCount >= this.maxConcurrent) {
-        logger.debug(
-          { processingCount, maxConcurrent: this.maxConcurrent },
-          "Max concurrent jobs reached, waiting..."
-        );
-        return;
-      }
-
-      // Get next pending job (atomically marks it as processing)
-      const job = getNextPendingJob();
-      if (!job) {
-        return; // No jobs to process
-      }
-
-      logger.info(
-        {
-          jobId: job.id,
-          filePath: job.file_path,
-          priority: job.priority,
-        },
-        "Starting video job processing"
-      );
-
-      // Emit started event
-      this.emit("job:started", job);
-
-      try {
-        // Parse params from JSON
-        const params = JSON.parse(job.params_json);
-
-        // Download source file if using cloud storage
-        let sourcePath = `./public/${job.file_path}`;
-        if (this.storage) {
-          try {
-            const fs = await import('fs/promises');
-            const path = await import('path');
-            
-            // Download to temp directory
-            const buffer = await this.storage.downloadOriginal(job.file_path);
-            const tempDir = './temp';
-            sourcePath = path.join(tempDir, path.basename(job.file_path));
-            await fs.writeFile(sourcePath, buffer);
-          } catch (error) {
-            logger.error(
-              { error: serializeError(error), filePath: job.file_path },
-              "Failed to download source file from cloud storage"
-            );
-            throw error;
-          }
+      while (true) {
+        const processingCount = countProcessingJobs();
+        if (processingCount >= this.maxConcurrent) {
+          logger.debug(
+            { processingCount, maxConcurrent: this.maxConcurrent },
+            "Max concurrent jobs reached, waiting..."
+          );
+          break;
         }
 
-        // Process video
-        const buffer = await transformVideo(sourcePath, params);
-
-        // Save to cache
-        await saveToCache(job.cache_path, buffer);
-
-        // Upload to cloud storage if configured
-        if (this.storage) {
-          const contentType = params.format === "jpg" || params.format === "png"
-            ? `image/${params.format}`
-            : "video/mp4";
-          await this.storage.upload(job.file_path, params, buffer, contentType);
+        // Get next pending job (atomically marks it as processing)
+        const job = getNextPendingJob();
+        if (!job) {
+          break; // No more pending jobs
         }
-
-        // Mark as completed
-        updateJobStatus(job.id, "completed", 100);
 
         logger.info(
-          { jobId: job.id, filePath: job.file_path },
-          "Video job completed successfully"
+          {
+            jobId: job.id,
+            filePath: job.file_path,
+            priority: job.priority,
+            processingCount: processingCount + 1,
+            maxConcurrent: this.maxConcurrent,
+          },
+          "Dispatching video job"
         );
 
-        // Emit completion event
-        this.emit("job:completed", { ...job, status: "completed", progress: 100 });
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : "Unknown error";
-
-        logger.error(
-          { error: serializeError(error), jobId: job.id, filePath: job.file_path },
-          "Video job processing failed"
-        );
-
-        // Check if we should retry
-        if (job.retry_count < job.max_retries) {
-          logger.info(
-            {
-              jobId: job.id,
-              retryCount: job.retry_count + 1,
-              maxRetries: job.max_retries,
-            },
-            "Scheduling job for retry"
+        // Fire and forget; errors are handled inside processJob
+        this.processJob(job).catch((error) => {
+          logger.error(
+            { error: serializeError(error), jobId: job.id },
+            "Unhandled error in job processing"
           );
-          
-          // IMPORTANT: Mark as error first, then retry will reset it to pending
-          updateJobStatus(job.id, "error", job.progress, errorMessage);
-          retryFailedJob(job.id);
-        } else {
-          // Mark as error if max retries reached
-          updateJobStatus(job.id, "error", job.progress, errorMessage);
-          this.emit("job:error", { ...job, status: "error", error: errorMessage }, error as Error);
-        }
+        });
       }
     } finally {
-      this.isProcessing = false;
+      this.isAcquiring = false;
+    }
+  }
+
+  /**
+   * Process a single video job (runs concurrently with other jobs)
+   */
+  private async processJob(job: VideoJob): Promise<void> {
+    // Emit started event
+    this.emit("job:started", job);
+
+    try {
+      // Parse params from JSON
+      const params = JSON.parse(job.params_json);
+
+      // Download source file if using cloud storage
+      let sourcePath = `./public/${job.file_path}`;
+      if (this.storage) {
+        try {
+          const fs = await import('fs/promises');
+          const path = await import('path');
+
+          // Download to temp directory
+          const buffer = await this.storage.downloadOriginal(job.file_path);
+          const tempDir = './temp';
+          sourcePath = path.join(tempDir, path.basename(job.file_path));
+          await fs.writeFile(sourcePath, buffer);
+        } catch (error) {
+          logger.error(
+            { error: serializeError(error), filePath: job.file_path },
+            "Failed to download source file from cloud storage"
+          );
+          throw error;
+        }
+      }
+
+      // Process video
+      const buffer = await transformVideo(sourcePath, params);
+
+      // Save to cache
+      await saveToCache(job.cache_path, buffer);
+
+      // Upload to cloud storage if configured
+      if (this.storage) {
+        const contentType = params.format === "jpg" || params.format === "png"
+          ? `image/${params.format}`
+          : "video/mp4";
+        await this.storage.upload(job.file_path, params, buffer, contentType);
+      }
+
+      // Mark as completed
+      updateJobStatus(job.id, "completed", 100);
+
+      logger.info(
+        { jobId: job.id, filePath: job.file_path },
+        "Video job completed successfully"
+      );
+
+      // Emit completion event
+      this.emit("job:completed", { ...job, status: "completed", progress: 100 });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error";
+
+      logger.error(
+        { error: serializeError(error), jobId: job.id, filePath: job.file_path },
+        "Video job processing failed"
+      );
+
+      // Check if we should retry
+      if (job.retry_count < job.max_retries) {
+        logger.info(
+          {
+            jobId: job.id,
+            retryCount: job.retry_count + 1,
+            maxRetries: job.max_retries,
+          },
+          "Scheduling job for retry"
+        );
+
+        // IMPORTANT: Mark as error first, then retry will reset it to pending
+        updateJobStatus(job.id, "error", job.progress, errorMessage);
+        retryFailedJob(job.id);
+      } else {
+        // Mark as error if max retries reached
+        updateJobStatus(job.id, "error", job.progress, errorMessage);
+        this.emit("job:error", { ...job, status: "error", error: errorMessage }, error as Error);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- The worker processed a single job per poll tick, so video throughput was effectively serial even though `MAX_CONCURRENT_JOBS` permits more.
- Split the loop into serialized **acquisition** (`fillAvailableSlots`) and concurrent **execution** (`processJob`): each acquired job is dispatched as a fire-and-forget promise until the concurrency limit is reached.
- Acquisition stays single-flight (`isAcquiring`) so overlapping ticks never grab the same job; `getNextPendingJob()` already marks jobs `processing` atomically.