### PR TITLE
fix(image): preserve aspect-ratio crop when combined with resize

### DIFF
--- a/apps/api/src/utils/image/index.ts
+++ b/apps/api/src/utils/image/index.ts
@@ -62,6 +62,11 @@ export const transformImage = async (inputPath: string, params: TransformParams)
   // 2. Apply aspect ratio (if specified)
   if (params.aspect) {
     image = await applyAspectRatio(image, params.aspect, params.gravity);
+    // Sharp only honors one resize() per pipeline, so a following resize would
+    // override the aspect-ratio crop. Materialize the crop into a buffer first.
+    if (params.resize || params.width || params.height) {
+      image = sharp(await image.toBuffer());
+    }
   }
 
   // 3. Apply resize (if width or height specified)


### PR DESCRIPTION
## Summary
- `ar_` combined with `w_`/`h_` silently dropped the aspect-ratio crop. `applyAspectRatio()` crops via `image.resize({ fit: 'cover' })`, then the width/height resize calls `image.resize()` again — and Sharp honors only the **last** `resize()` in a pipeline, so the crop was discarded.
- Fix: after the aspect-ratio crop, if a resize is also requested, materialize the crop into a buffer (`sharp(await image.toBuffer())`) before the next `resize()` runs.


