### PR TITLE
perf(image): use async fs for temp-file I/O in transform path

### DIFF
--- a/apps/api/src/routes/transform-helpers.ts
+++ b/apps/api/src/routes/transform-helpers.ts
@@ -226,17 +226,15 @@ export async function prepareSourceFile(
     const sourceBuffer = await storage.downloadOriginal(filePath);
 
     // Temporarily save the file locally for processing
-    const fs = await import("fs");
+    const { mkdir, writeFile } = await import("fs/promises");
     const path = await import("path");
     const tempDir = "./temp";
-    if (!fs.existsSync(tempDir)) {
-      fs.mkdirSync(tempDir, { recursive: true });
-    }
+    await mkdir(tempDir, { recursive: true });
     const tempPath = path.join(
       tempDir,
       `${crypto.randomUUID()}-${path.basename(filePath)}`,
     );
-    fs.writeFileSync(tempPath, sourceBuffer);
+    await writeFile(tempPath, sourceBuffer);
     return tempPath;
   } else {
     logger.debug({ localPath }, "Processing from local file");
@@ -258,9 +256,9 @@ export async function processImage(
   const basicBuffer = await transformImage(originalPath, params);
 
   // Temporary save for advanced optimization
-  const fs = await import("fs");
+  const { writeFile, unlink } = await import("fs/promises");
   const tempOptimPath = originalPath + `.${crypto.randomUUID()}.temp`;
-  fs.writeFileSync(tempOptimPath, basicBuffer);
+  await writeFile(tempOptimPath, basicBuffer);
 
   try {
     // Advanced optimization
@@ -274,7 +272,7 @@ export async function processImage(
     const contentType = `image/${optimizationResult.format}`;
 
     // Cleanup temporary file
-    fs.unlinkSync(tempOptimPath);
+    await unlink(tempOptimPath);
 
     return {
       buffer: optimizationResult.buffer,
@@ -301,7 +299,7 @@ export async function processImage(
 
     // Cleanup in case of error
     try {
-      fs.unlinkSync(tempOptimPath);
+      await unlink(tempOptimPath);
     } catch {
       // Ignore cleanup errors
     }


### PR DESCRIPTION
## Summary
- `prepareSourceFile` and `processImage` saved and deleted temp source/output files with `fs.writeFileSync`/`unlinkSync`. These block the event loop on potentially large image buffers while other transform requests are in flight.
- Switch the per-request temp-file I/O to `fs/promises` (`writeFile`/`unlink`). `mkdir({ recursive: true })` also replaces the `existsSync` + `mkdirSync` pair (idempotent, one fewer syscall).

Scope is limited to the per-request temp-file buffer I/O; startup/dir-setup sync calls elsewhere are left as-is.
