### PR TITLE
fix: API key Bearer auth bypass + doc corrections

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -139,6 +139,16 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // Allow API requests with Bearer token through — API key validation happens in the Hono backend
+  const authHeader = request.headers.get("Authorization");
+  if (authHeader?.startsWith("Bearer ")) {
+    const response = NextResponse.next();
+    if (pathname.startsWith("/api/")) {
+      return addCorsHeaders(response, allowedOrigin, requestOrigin, pathname);
+    }
+    return response;
+  }
+
   // If user is not authenticated, redirect to login
   // The login page will handle redirecting to setup if needed
   const authenticated = await isAuthenticated(request);

--- a/docs/api-reference/api-keys/create.mdx
+++ b/docs/api-reference/api-keys/create.mdx
@@ -37,9 +37,9 @@ POST /api-keys/create
   "success": true,
   "apiKey": {
     "id": "key_abc123",
-    "key": "oink_xxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "key": "xxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "name": "production",
-    "start": "oink_xxx",
+    "start": "xxxxxx",
     "createdAt": "2024-03-15T10:30:00.000Z",
     "expiresAt": "2025-03-15T10:30:00.000Z"
   },

--- a/docs/api-reference/api-keys/list.mdx
+++ b/docs/api-reference/api-keys/list.mdx
@@ -20,8 +20,8 @@ GET /api-keys/list
     {
       "id": "key_abc123",
       "name": "production",
-      "start": "oink_xxx",
-      "prefix": "oink_",
+      "start": "xxxxxx",
+      "prefix": null,
       "enabled": true,
       "expiresAt": "2025-03-15T10:30:00.000Z",
       "createdAt": "2024-03-15T10:30:00.000Z",
@@ -38,7 +38,7 @@ GET /api-keys/list
     <ResponseField name="id" type="string">Unique identifier. Used for update/delete.</ResponseField>
     <ResponseField name="name" type="string">Display name.</ResponseField>
     <ResponseField name="start" type="string">Key prefix — safe to display, uniquely identifies the key without exposing the full value.</ResponseField>
-    <ResponseField name="prefix" type="string">Key type prefix (e.g. `oink_`).</ResponseField>
+    <ResponseField name="prefix" type="string">Key type prefix. `null` if no prefix is configured.</ResponseField>
     <ResponseField name="enabled" type="boolean">Whether the key is currently active.</ResponseField>
     <ResponseField name="expiresAt" type="string">ISO 8601 expiration timestamp.</ResponseField>
     <ResponseField name="createdAt" type="string">ISO 8601 creation timestamp.</ResponseField>

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
 import fs from "fs";
+import crypto from "crypto";
 
 // Get the project root directory (3 levels up from this file)
 const __filename = fileURLToPath(import.meta.url);
@@ -12,16 +13,32 @@ const __dirname = dirname(__filename);
 const projectRoot = path.resolve(__dirname, "../../../");
 
 // Configurable database path via environment variable
-const dataDir = process.env.DB_PATH 
+const dataDir = process.env.DB_PATH
   ? path.dirname(process.env.DB_PATH)
   : path.join(projectRoot, "data");
 const dbPath = process.env.DB_PATH || path.join(dataDir, "auth.db");
 
+// Load BETTER_AUTH_SECRET from root .env if not already in process.env.
+// This avoids duplicating the secret in each app's individual .env file.
+if (!process.env.BETTER_AUTH_SECRET) {
+  const rootEnvPath = path.join(projectRoot, ".env");
+  if (fs.existsSync(rootEnvPath)) {
+    const lines = fs.readFileSync(rootEnvPath, "utf-8").split("\n");
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("BETTER_AUTH_SECRET=") && !trimmed.startsWith("#")) {
+        process.env.BETTER_AUTH_SECRET = trimmed.slice("BETTER_AUTH_SECRET=".length).trim();
+        break;
+      }
+    }
+  }
+}
+
 // Security validation for production
-const secret = process.env.BETTER_AUTH_SECRET;
 const isProduction = process.env.NODE_ENV === "production";
-const isBuildTime = process.env.NEXT_PHASE === "phase-production-build" || 
+const isBuildTime = process.env.NEXT_PHASE === "phase-production-build" ||
                     process.env.npm_lifecycle_event === "build";
+const secret = process.env.BETTER_AUTH_SECRET;
 
 // Only validate secrets at runtime, not during build
 if (isProduction && !isBuildTime) {
@@ -32,7 +49,7 @@ if (isProduction && !isBuildTime) {
       "Generate one with: openssl rand -hex 32"
     );
   }
-  
+
   // Critical: Secret must not be the build-time placeholder
   if (secret === "build-time-secret-will-be-replaced") {
     throw new Error(
@@ -40,7 +57,7 @@ if (isProduction && !isBuildTime) {
       "You must set a unique secret in production."
     );
   }
-  
+
   // Warning: Secret should be strong (at least 32 characters)
   if (secret.length < 32) {
     console.warn(
@@ -48,6 +65,12 @@ if (isProduction && !isBuildTime) {
       "For better security, use: openssl rand -hex 32"
     );
   }
+} else if (!isProduction && !isBuildTime && !secret) {
+  throw new Error(
+    "🚨 BETTER_AUTH_SECRET is not set.\n" +
+    "Add it to your root .env file: BETTER_AUTH_SECRET=<your-secret>\n" +
+    "Generate one with: openssl rand -hex 32"
+  );
 } else if (isBuildTime && secret === "build-time-secret-will-be-replaced") {
   console.warn("Build phase detected - using placeholder secret (will be validated at runtime)");
 }
@@ -291,6 +314,27 @@ function initializeTables() {
 
 // Initialize tables before creating Better Auth instance
 initializeTables();
+
+// Validate that the secret hasn't changed between processes or restarts.
+// Stores a SHA-256 hash of the secret in the DB on first use; throws if it
+// differs on subsequent startups (would invalidate all existing sessions).
+(function validateSecretConsistency() {
+  if (!secret || isBuildTime) return;
+
+  db.exec(`CREATE TABLE IF NOT EXISTS _auth_config (key TEXT PRIMARY KEY, value TEXT NOT NULL)`);
+
+  const hash = crypto.createHash("sha256").update(secret).digest("hex");
+  const row = db.prepare("SELECT value FROM _auth_config WHERE key = 'secret_hash'").get() as { value: string } | undefined;
+
+  if (!row) {
+    db.prepare("INSERT INTO _auth_config (key, value) VALUES ('secret_hash', ?)").run(hash);
+  } else if (row.value !== hash) {
+    throw new Error(
+      "🚨 BETTER_AUTH_SECRET mismatch: the secret has changed since the database was created.\n" +
+      "All existing sessions will be invalid. If this is intentional, delete the _auth_config table row with key='secret_hash' and restart."
+    );
+  }
+})();
 
 const publicAuthUrl = process.env.BETTER_AUTH_URL;
 const internalAuthUrl = process.env.BETTER_AUTH_INTERNAL_URL;


### PR DESCRIPTION
## Summary

Fixes #69 — two bugs reported in the issue plus a related dev reliability fix:

- **Bearer token redirect**: Requests with `Authorization: Bearer <token>` were being redirected to `/login` by the Next.js middleware before reaching the Hono backend. Added an early return to pass Bearer requests through; API key validation still happens correctly in the Hono `apiKeyAuth` middleware.
- **Docs mismatch (`oink_` prefix)**: Documentation showed `oink_` prefix on generated API keys but the codebase never configures a prefix. Corrected both `create.mdx` and `list.mdx` to reflect actual behavior (`prefix: null`).
- **Multi-process secret reliability**: In dev, Next.js and Hono run as separate OS processes. If `BETTER_AUTH_SECRET` is unset, Better Auth generates a different random secret per process → sessions signed by one process are rejected by the other (401 on every API call). Fixed by:
  - Auto-loading `BETTER_AUTH_SECRET` from the root `.env` file in the shared auth package (single source of truth, no duplication needed in each app's `.env`)
  - Throwing an explicit error in dev when the secret is missing (instead of silent random fallback)
  - Validating secret consistency on startup via SHA-256 hash stored in a `_auth_config` SQLite table — throws if the secret changes between restarts or differs between processes

## Test plan

- [x] `curl -X POST http://localhost:3000/upload -H "Authorization: Bearer <key>" -F "files=@file.jpg"` → 200 OK
- [x] Dashboard loads without 401 on `/storage` after fresh account login
- [x] `pnpm dev` throws a clear error if `BETTER_AUTH_SECRET` is missing from root `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)