### PR TITLE
feat: add anonymous usage telemetry

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -8,6 +8,7 @@ import path from "path";
 import { randomUUID } from "crypto";
 import logger, { serializeError } from "./utils/logger";
 import { videoJobQueue } from "./utils/video-job-queue";
+import { initTelemetry } from "./utils/telemetry";
 
 // Function to clean local cache in cloud mode on startup
 const cleanupLocalCacheIfCloudMode = () => {
@@ -113,6 +114,9 @@ serve({
 });
 
 logger.info({ port }, "Server running");
+
+// Anonymous usage telemetry (non-blocking, opt-out via OPENINARY_TELEMETRY=false)
+initTelemetry();
 
 // Initialize auth in background (non-blocking)
 // This allows the server to respond to healthchecks immediately

--- a/apps/api/src/utils/telemetry.ts
+++ b/apps/api/src/utils/telemetry.ts
@@ -1,0 +1,196 @@
+import os from "os";
+import { db } from "shared/auth";
+import logger from "./logger";
+
+/**
+ * Anonymous usage telemetry.
+ *
+ * What this sends and why: see /docs/TELEMETRY.md.
+ * - No PII, no file names, no media content, no IPs are collected here.
+ * - Every property is bucketed/enumerated — never a raw count or free-text value.
+ * - Disable entirely with OPENINARY_TELEMETRY=false.
+ *
+ * Events are NOT sent directly to PostHog. They go through a small proxy
+ * (telemetry.openinary.dev) that holds the real PostHog key, validates the
+ * payload against this same whitelist, and rate-limits per instance.
+ */
+
+const TELEMETRY_ENDPOINT =
+  process.env.TELEMETRY_ENDPOINT || "https://telemetry.openinary.dev/collect";
+const TELEMETRY_ENABLED = process.env.OPENINARY_TELEMETRY !== "false";
+const HEARTBEAT_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+const HEARTBEAT_JITTER_MS = 60 * 60 * 1000; // +/- up to 1h, avoids thundering herd
+const SEND_TIMEOUT_MS = 3000;
+
+type CountBucket = "0" | "1-10" | "11-100" | "101-1000" | "1000+";
+
+function bucketCount(n: number): CountBucket {
+  if (n <= 0) return "0";
+  if (n <= 10) return "1-10";
+  if (n <= 100) return "11-100";
+  if (n <= 1000) return "101-1000";
+  return "1000+";
+}
+
+function ensureTelemetryTable() {
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS _telemetry_config (key TEXT PRIMARY KEY, value TEXT NOT NULL)`
+  );
+}
+
+function getConfig(key: string): string | undefined {
+  const row = db
+    .prepare("SELECT value FROM _telemetry_config WHERE key = ?")
+    .get(key) as { value: string } | undefined;
+  return row?.value;
+}
+
+function setConfig(key: string, value: string) {
+  db.prepare(
+    "INSERT INTO _telemetry_config (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+  ).run(key, value);
+}
+
+function getOrCreateInstanceId(): string {
+  const existing = getConfig("instance_id");
+  if (existing) return existing;
+  const id = crypto.randomUUID();
+  setConfig("instance_id", id);
+  return id;
+}
+
+function getVersion(): string {
+  return process.env.IMAGE_TAG || "unknown";
+}
+
+function getDeploymentMode(): string {
+  return process.env.MODE || "fullstack";
+}
+
+function getStorageBackend(): "s3" | "local" {
+  // Presence of any S3-compatible config indicates cloud storage.
+  return process.env.S3_BUCKET || process.env.AWS_S3_BUCKET ? "s3" : "local";
+}
+
+function getVideoJobCount(): number {
+  try {
+    const row = db.prepare("SELECT COUNT(*) as count FROM video_jobs").get() as
+      | { count: number }
+      | undefined;
+    return row?.count ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+// Whitelist of every event this codebase is allowed to emit, and the exact
+// property shape each one carries. Keep this in sync with the proxy's schema.
+type TelemetryEvent =
+  | {
+      event: "instance_started";
+      properties: {
+        version: string;
+        deployment_mode: string;
+        storage_backend: "s3" | "local";
+        os_platform: string;
+        os_arch: string;
+        node_version: string;
+      };
+    }
+  | {
+      event: "daily_heartbeat";
+      properties: {
+        version: string;
+        deployment_mode: string;
+        storage_backend: "s3" | "local";
+        video_jobs_bucket: CountBucket;
+      };
+    };
+
+async function send(instanceId: string, payload: TelemetryEvent) {
+  if (!TELEMETRY_ENABLED) return;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SEND_TIMEOUT_MS);
+
+  try {
+    await fetch(TELEMETRY_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        instance_id: instanceId,
+        event: payload.event,
+        properties: payload.properties,
+        timestamp: new Date().toISOString(),
+      }),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    // Telemetry must never affect the running instance.
+    logger.debug({ error }, "Telemetry send failed (ignored)");
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function buildBaseProperties() {
+  return {
+    version: getVersion(),
+    deployment_mode: getDeploymentMode(),
+    storage_backend: getStorageBackend(),
+  };
+}
+
+async function sendHeartbeat(instanceId: string) {
+  await send(instanceId, {
+    event: "daily_heartbeat",
+    properties: {
+      ...buildBaseProperties(),
+      video_jobs_bucket: bucketCount(getVideoJobCount()),
+    },
+  });
+  setConfig("last_heartbeat_at", Date.now().toString());
+}
+
+/**
+ * Starts anonymous telemetry: fires `instance_started` once ever, then a
+ * `daily_heartbeat` roughly every 24h for the lifetime of the process.
+ * No-op (besides logging) if OPENINARY_TELEMETRY=false.
+ */
+export function initTelemetry() {
+  if (!TELEMETRY_ENABLED) {
+    logger.info("Telemetry disabled (OPENINARY_TELEMETRY=false)");
+    return;
+  }
+
+  ensureTelemetryTable();
+  const instanceId = getOrCreateInstanceId();
+
+  if (!getConfig("first_started_at")) {
+    setConfig("first_started_at", Date.now().toString());
+    send(instanceId, {
+      event: "instance_started",
+      properties: {
+        ...buildBaseProperties(),
+        os_platform: os.platform(),
+        os_arch: os.arch(),
+        node_version: process.version,
+      },
+    });
+  }
+
+  // Send a heartbeat if the last one is missing or older than the interval,
+  // then keep sending on a jittered daily interval for as long as the process runs.
+  const lastHeartbeatAt = Number(getConfig("last_heartbeat_at") || 0);
+  const dueIn = Math.max(0, HEARTBEAT_INTERVAL_MS - (Date.now() - lastHeartbeatAt));
+  const jitter = Math.floor(Math.random() * HEARTBEAT_JITTER_MS);
+
+  setTimeout(() => {
+    sendHeartbeat(instanceId);
+    setInterval(() => {
+      sendHeartbeat(instanceId);
+    }, HEARTBEAT_INTERVAL_MS + Math.floor(Math.random() * HEARTBEAT_JITTER_MS)).unref();
+  }, dueIn + jitter).unref();
+
+  logger.info({ instanceId }, "Telemetry initialized");
+}

--- a/docker.env.example
+++ b/docker.env.example
@@ -65,3 +65,12 @@ DOCKER_MEMORY_LIMIT=4G
 # DOCKER_CPU_LIMIT=4.0
 # DOCKER_MEMORY_LIMIT=12G
 # VIDEO_MAX_CONCURRENT=4
+
+# ============================================
+# Anonymous Usage Telemetry (Optional)
+# ============================================
+# Openinary sends a small, anonymous, aggregated usage ping on startup and
+# then once a day (instance ID, version, deployment mode, bucketed counts).
+# No file names, media content, or IP addresses are ever collected.
+# See docs/configuration/telemetry.mdx for the exact payload. Disable with:
+# OPENINARY_TELEMETRY=false

--- a/docs/configuration/telemetry.mdx
+++ b/docs/configuration/telemetry.mdx
@@ -1,0 +1,39 @@
+---
+title: "Telemetry"
+description: "What anonymous usage data Openinary collects, and how to disable it"
+---
+
+Openinary sends a small amount of anonymous, aggregated usage data to help prioritize development. This page lists **exactly** what is sent — nothing more.
+
+## Why
+
+Openinary is self-hosted and the entire codebase is public, so there is no way to track usage the way a hosted SaaS would. Without any signal, it's hard to know which features are actually used or how many instances exist. Telemetry gives directional data (not precise counts) while staying anonymous.
+
+## What is sent
+
+Two events, both with a fixed, whitelisted set of properties. No file names, media content, URLs, user data, or IP addresses are ever included.
+
+| Event | When | Properties |
+|-------|------|------------|
+| `instance_started` | Once, on first ever boot of an instance | `version`, `deployment_mode`, `storage_backend`, `os_platform`, `os_arch`, `node_version` |
+| `daily_heartbeat` | Once every ~24h while the process runs | `version`, `deployment_mode`, `storage_backend`, `video_jobs_bucket` |
+
+Counts are never sent as raw numbers — they're bucketed into ranges (`0`, `1-10`, `11-100`, `101-1000`, `1000+`).
+
+Each instance has a random UUID (`instance_id`) generated on first boot and stored in the local database. It cannot be linked back to you or your data.
+
+## Where it goes
+
+Events are sent to `telemetry.openinary.dev`, a small proxy maintained by the Openinary project. The proxy validates the payload against the same whitelist, rate-limits per instance, and forwards accepted events to a PostHog project. Your instance never talks to PostHog directly, and never holds a PostHog key.
+
+## Disabling it
+
+<ParamField path="OPENINARY_TELEMETRY" type="boolean" default="true">
+  Set to `false` to disable telemetry entirely. No requests are made.
+</ParamField>
+
+```bash
+OPENINARY_TELEMETRY=false
+```
+
+The code that generates and sends these events lives in [`apps/api/src/utils/telemetry.ts`](https://github.com/openinary/openinary/blob/main/apps/api/src/utils/telemetry.ts) — read it if you want to verify this page is accurate.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -35,7 +35,8 @@
               "configuration/server",
               "configuration/storage",
               "configuration/video-processing",
-              "configuration/docker-resources"
+              "configuration/docker-resources",
+              "configuration/telemetry"
             ]
           },
           {


### PR DESCRIPTION
## Summary
- Adds opt-out anonymous telemetry (`OPENINARY_TELEMETRY=false`): one `instance_started` ping on first boot, then a `daily_heartbeat` roughly every 24h.
- Every property is bucketed or enum-valued — no PII, no file names/paths, no raw counts, no IP collected in the payload.
- Events are sent to `telemetry.openinary.dev`, a private proxy (separate repo, not part of this codebase) that validates against the same whitelist, rate-limits per instance/IP, and forwards to PostHog. This repo never holds a PostHog key.
- Documented in `docs/configuration/telemetry.mdx`, including the exact payload shape, so self-hosters can verify the claim by reading the linked source.

## Test plan
- [x] `pnpm --filter api type-check` passes
- [x] Started the API locally with `TELEMETRY_ENDPOINT` pointed at the deployed proxy; confirmed `instance_started` fired with a real generated `instance_id` and the proxy returned `Ok` (verified via `wrangler tail`)
- [x] Verified event landed in PostHog Activity view
- [x] Confirmed `OPENINARY_TELEMETRY=false` short-circuits `initTelemetry()` with no network calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)