### PR TITLE
fix(api): detect video worker concurrency from cgroup memory limit

### DIFF
--- a/apps/api/src/utils/video/config.ts
+++ b/apps/api/src/utils/video/config.ts
@@ -3,31 +3,79 @@
  * These values can be overridden via environment variables
  */
 
+import * as fs from "fs";
 import * as os from "os";
 
+const CGROUP_V2_MAX_PATH = "/sys/fs/cgroup/memory.max";
+const CGROUP_V1_LIMIT_PATH = "/sys/fs/cgroup/memory/memory.limit_in_bytes";
+// cgroup v1 reports this (or similar huge values) when no limit is set
+const CGROUP_V1_UNLIMITED_THRESHOLD = 1e18;
+
 /**
- * Detect optimal number of concurrent video jobs based on available RAM
- * Formula: 1 worker per 2GB of RAM (minimum 1, maximum 16)
+ * Read the container memory limit from cgroup v2 or v1, if present.
+ * Returns null when no cgroup file is found or the limit is "unlimited".
  */
-function detectOptimalConcurrency(): number {
-  const totalMemoryGB = os.totalmem() / (1024 ** 3);
-  const optimal = Math.max(1, Math.floor(totalMemoryGB / 2));
+function readCgroupMemoryLimit(): number | null {
+  try {
+    const raw = fs.readFileSync(CGROUP_V2_MAX_PATH, "utf8").trim();
+    if (raw === "max") return null;
+    const value = parseInt(raw, 10);
+    return Number.isFinite(value) ? value : null;
+  } catch {
+    // cgroup v2 file not present, fall through to v1
+  }
+
+  try {
+    const raw = fs.readFileSync(CGROUP_V1_LIMIT_PATH, "utf8").trim();
+    const value = parseInt(raw, 10);
+    if (!Number.isFinite(value) || value >= CGROUP_V1_UNLIMITED_THRESHOLD) return null;
+    return value;
+  } catch {
+    // cgroup v1 file not present either
+  }
+
+  return null;
+}
+
+/**
+ * Effective memory available to the process: the lower of the host RAM
+ * and the container's cgroup memory limit (if one is set).
+ */
+function getEffectiveMemoryBytes(): { bytes: number; source: "cgroup limit" | "host RAM" } {
+  const cgroupLimit = readCgroupMemoryLimit();
+  const hostMemory = os.totalmem();
+  if (cgroupLimit !== null && cgroupLimit < hostMemory) {
+    return { bytes: cgroupLimit, source: "cgroup limit" };
+  }
+  return { bytes: hostMemory, source: "host RAM" };
+}
+
+/**
+ * Detect optimal number of concurrent video jobs based on available memory
+ * Formula: 1 worker per 2GB of memory (minimum 1, maximum 16)
+ */
+function detectOptimalConcurrency(memoryBytes: number): number {
+  const memoryGB = memoryBytes / (1024 ** 3);
+  const optimal = Math.max(1, Math.floor(memoryGB / 2));
   // Cap at 16 workers to prevent excessive resource usage
   return Math.min(optimal, 16);
 }
 
+const { bytes: effectiveMemoryBytes, source: memorySource } = getEffectiveMemoryBytes();
+
 /**
  * Maximum number of concurrent video jobs
- * Auto-detected based on system RAM, or configured via VIDEO_MAX_CONCURRENT env variable
+ * Auto-detected based on available memory (host RAM or cgroup limit, whichever is
+ * lower), or configured via VIDEO_MAX_CONCURRENT env variable
  */
 export const MAX_CONCURRENT_JOBS = process.env.VIDEO_MAX_CONCURRENT
   ? parseInt(process.env.VIDEO_MAX_CONCURRENT, 10)
-  : detectOptimalConcurrency();
+  : detectOptimalConcurrency(effectiveMemoryBytes);
 
 // Log detected configuration on module load
-const totalMemoryGB = (os.totalmem() / (1024 ** 3)).toFixed(2);
-const configSource = process.env.VIDEO_MAX_CONCURRENT ? "env variable" : "auto-detected";
-console.log(`[Video Config] RAM: ${totalMemoryGB}GB | Max concurrent jobs: ${MAX_CONCURRENT_JOBS} (${configSource})`);
+const effectiveMemoryGB = (effectiveMemoryBytes / (1024 ** 3)).toFixed(2);
+const configSource = process.env.VIDEO_MAX_CONCURRENT ? "env variable" : memorySource;
+console.log(`[Video Config] Memory: ${effectiveMemoryGB}GB (${memorySource}) | Max concurrent jobs: ${MAX_CONCURRENT_JOBS} (${configSource})`);
 
 /**
  * Maximum number of retry attempts for failed jobs


### PR DESCRIPTION
## Summary
- `VIDEO_MAX_CONCURRENT` auto-detection used `os.totalmem()`, which reports the **host's** total RAM, not the container's memory limit.
- On deployments where the container is capped below host RAM (e.g. Coolify on a large VPS), this over-provisions concurrent ffmpeg jobs (1 worker per 2GB of *host* RAM instead of *container* RAM), inflating memory usage during video processing.
- Now reads the cgroup memory limit (`/sys/fs/cgroup/memory.max` for v2, `memory.limit_in_bytes` for v1) and uses the lower of that and host RAM. Falls back to host RAM when no cgroup limit is set (e.g. bare metal, or unlimited cgroup).
- `VIDEO_MAX_CONCURRENT` env override behavior is unchanged.

## Test plan
- [x] Reviewed cgroup v2 (`memory.max` = `"max"` for unlimited) and v1 (huge sentinel value for unlimited) handling
- [x] Deploy to a Coolify/Railway instance with a container memory limit below host RAM and confirm `[Video Config]` log line reports the cgroup limit and a lower worker count
- [x] Confirm behavior unchanged when `VIDEO_MAX_CONCURRENT` env var is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)