### PR TITLE
fix(docker): preload jemalloc to release RSS after video/image jobs

### DIFF
--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -1,8 +1,14 @@
 FROM node:20-slim
 
-# Install ffmpeg for video processing and openssl for Prisma/better-auth
-RUN apt-get update && apt-get install -y --no-install-recommends openssl ffmpeg sqlite3 && \
-    rm -rf /var/lib/apt/lists/*
+# Install ffmpeg for video processing, openssl for Prisma/better-auth, and jemalloc
+# to avoid RSS bloat from glibc arena fragmentation under sharp/libvips and ffmpeg workloads
+RUN apt-get update && apt-get install -y --no-install-recommends openssl ffmpeg sqlite3 libjemalloc2 && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -sf "$(dpkg -L libjemalloc2 | grep 'libjemalloc\.so\.2$')" /usr/lib/libjemalloc.so.2
+
+# Reduce glibc malloc arena fragmentation and preload jemalloc as the allocator
+ENV MALLOC_ARENA_MAX=2
+ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
 
 # Enable Corepack to use the pnpm version specified in package.json
 RUN corepack enable && corepack prepare pnpm@9.0.0 --activate

--- a/docker/full.Dockerfile
+++ b/docker/full.Dockerfile
@@ -65,9 +65,17 @@ FROM node:20-slim
 ARG NEXT_PUBLIC_API_BASE_URL="/api"
 ARG IMAGE_TAG="latest"
 
-# Install nginx, ffmpeg, supervisor, cron and sqlite3 for process management
-RUN apt-get update && apt-get install -y --no-install-recommends nginx ffmpeg supervisor cron sqlite3 && \
-    rm -rf /var/lib/apt/lists/*
+# Install nginx, ffmpeg, supervisor, cron, sqlite3 and jemalloc for process management
+# jemalloc replaces glibc malloc to avoid RSS bloat from arena fragmentation under
+# sharp/libvips and ffmpeg workloads (freed memory not returned to the OS)
+RUN apt-get update && apt-get install -y --no-install-recommends nginx ffmpeg supervisor cron sqlite3 libjemalloc2 && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -sf "$(dpkg -L libjemalloc2 | grep 'libjemalloc\.so\.2$')" /usr/lib/libjemalloc.so.2
+
+# Reduce glibc malloc arena fragmentation and preload jemalloc as the allocator for
+# all supervised processes (api, web)
+ENV MALLOC_ARENA_MAX=2
+ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
 
 WORKDIR /app
 

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -12,7 +12,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-environment=NODE_ENV="production",PORT="3002",BETTER_AUTH_SECRET="%(ENV_BETTER_AUTH_SECRET)s",BETTER_AUTH_URL="%(ENV_BETTER_AUTH_URL)s",MODE="%(ENV_MODE)s"
+environment=NODE_ENV="production",PORT="3002",BETTER_AUTH_SECRET="%(ENV_BETTER_AUTH_SECRET)s",BETTER_AUTH_URL="%(ENV_BETTER_AUTH_URL)s",MODE="%(ENV_MODE)s",MALLOC_ARENA_MAX="%(ENV_MALLOC_ARENA_MAX)s",LD_PRELOAD="%(ENV_LD_PRELOAD)s"
 
 [program:web]
 command=node /app/web-standalone/apps/web/server.js
@@ -23,7 +23,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
-environment=NODE_ENV="production",PORT="3001",HOSTNAME="0.0.0.0",NEXT_PUBLIC_API_BASE_URL="/api",BETTER_AUTH_SECRET="%(ENV_BETTER_AUTH_SECRET)s",BETTER_AUTH_URL="%(ENV_BETTER_AUTH_URL)s"
+environment=NODE_ENV="production",PORT="3001",HOSTNAME="0.0.0.0",NEXT_PUBLIC_API_BASE_URL="/api",BETTER_AUTH_SECRET="%(ENV_BETTER_AUTH_SECRET)s",BETTER_AUTH_URL="%(ENV_BETTER_AUTH_URL)s",MALLOC_ARENA_MAX="%(ENV_MALLOC_ARENA_MAX)s",LD_PRELOAD="%(ENV_LD_PRELOAD)s"
 
 [program:nginx]
 command=/usr/sbin/nginx -g "daemon off;"


### PR DESCRIPTION
## Summary
- Node + glibc malloc fragments badly under `sharp`/libvips and ffmpeg workloads: memory freed after processing isn't returned to the OS, so container RSS plateaus at the historical peak (e.g. 500MB+) for hours with zero activity, only dropping after a restart. This matches an observed Railway memory graph (265MB idle → 570MB during light video processing → plateau at 500MB+ overnight → drop to 163MB after restart).
- This is the allocator-tuning fix `sharp`'s maintainers recommend for exactly this scenario.
- Installs `libjemalloc2` and preloads it via `LD_PRELOAD` in both `docker/api.Dockerfile` and `docker/full.Dockerfile`.
- Also sets `MALLOC_ARENA_MAX=2` to reduce glibc arena fragmentation as a belt-and-suspenders measure.
- `docker/supervisord.conf` explicitly forwards `MALLOC_ARENA_MAX`/`LD_PRELOAD` to the `api` and `web` supervised programs — supervisord does not inherit the container's environment into child processes by default, so without this the preload would be silently ineffective for both.

## Test plan
- [x] Built `docker/api.Dockerfile` locally — succeeds
- [x] Verified `/usr/lib/libjemalloc.so.2` symlink resolves correctly on the current `node:20-slim` base
- [x] Verified `MALLOC_ARENA_MAX`/`LD_PRELOAD` are present in the container environment
- [x] Started a `node` process inside the built image and confirmed jemalloc is actually mapped via `/proc/<pid>/maps` (not just an inert env var)
- [x] Deploy to Railway/Coolify and confirm RSS drops back down after a video/image processing burst instead of plateauing