### PR TITLE
fix(api): stop video jobs from starving HTTP serving on small containers

### DIFF
--- a/apps/api/src/routes/authenticated.ts
+++ b/apps/api/src/routes/authenticated.ts
@@ -140,19 +140,24 @@ t.get('/*', async (c) => {
       c.header('Content-Type', result.contentType);
     }
 
+    // Large payloads (e.g. original videos during processing) are streamed
+    if (result.stream) {
+      return c.body(result.stream);
+    }
+
     // Check if this is an error response
     if (
       result.contentType === 'text/plain' &&
-      result.buffer.toString().includes('failed')
+      result.buffer!.toString().includes('failed')
     ) {
-      const errorMessage = result.buffer.toString();
+      const errorMessage = result.buffer!.toString();
       if (errorMessage.includes('File not found')) {
         return c.text(errorMessage, 404);
       }
       return c.text(errorMessage, 500);
     }
 
-    return c.body(new Uint8Array(result.buffer));
+    return c.body(new Uint8Array(result.buffer!));
   } catch (error) {
     logger.error({ error: serializeError(error), path }, 'Authenticated transform route error');
     return c.text('Internal server error', 500);

--- a/apps/api/src/routes/transform.ts
+++ b/apps/api/src/routes/transform.ts
@@ -45,19 +45,24 @@ t.get('/*', async (c) => {
       c.header('Content-Type', result.contentType);
     }
 
+    // Large payloads (e.g. original videos during processing) are streamed
+    if (result.stream) {
+      return c.body(result.stream);
+    }
+
     // Check if this is an error response
     if (
       result.contentType === 'text/plain' &&
-      result.buffer.toString().includes('failed')
+      result.buffer!.toString().includes('failed')
     ) {
-      const errorMessage = result.buffer.toString();
+      const errorMessage = result.buffer!.toString();
       if (errorMessage.includes('File not found')) {
         return c.text(errorMessage, 404);
       }
       return c.text(errorMessage, 500);
     }
 
-    return c.body(new Uint8Array(result.buffer));
+    return c.body(new Uint8Array(result.buffer!));
   } catch (error) {
     logger.error({ error: serializeError(error), path }, 'Transform route error');
     return c.text('Internal server error', 500);

--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -173,7 +173,8 @@ async function prewarmImageTransformations(
         context: c,
       });
 
-      const errorText = result.buffer.toString();
+      // prewarm only runs for images, which are always buffered (never streamed)
+      const errorText = result.buffer?.toString() ?? "";
       const failed =
         result.contentType === "text/plain" && errorText.includes("failed");
 

--- a/apps/api/src/services/transform.service.ts
+++ b/apps/api/src/services/transform.service.ts
@@ -6,7 +6,6 @@ import { Compression } from '../utils/image/compression';
 import logger, { serializeError } from '../utils/logger';
 import { videoJobQueue } from '../utils/video-job-queue';
 import { updateJobStatus } from '../utils/video/queue-db';
-import { readFile } from 'fs/promises';
 import {
   checkCloudCache,
   checkLocalCache,
@@ -29,7 +28,9 @@ export interface TransformRequest {
 }
 
 export interface TransformResult {
-  buffer: Buffer;
+  buffer?: Buffer;
+  /** Set instead of buffer for large payloads served without in-memory buffering */
+  stream?: ReadableStream<Uint8Array>;
   contentType: string;
   headers: Record<string, string>;
   isProcessing?: boolean;
@@ -245,6 +246,21 @@ export class TransformService {
     userAgent?: string,
     acceptHeader?: string
   ): Promise<TransformResult> {
+    // Video transformations (non-thumbnail) are processed by the background
+    // job queue, which downloads its own source copy. Skip prepareSourceFile
+    // entirely: downloading the full original here would only delay the
+    // response and waste memory/bandwidth.
+    const isThumbnailRequest =
+      effectiveParams.thumbnail === 'true' || effectiveParams.thumbnail === '1';
+    if (ext?.match(/mp4|mov|webm/) && !isThumbnailRequest) {
+      return await this.handleVideoJobQueue(
+        filePath,
+        localPath,
+        effectiveParams,
+        cachePath
+      );
+    }
+
     // Prepare source file
     const sourcePath = await prepareSourceFile(
       this.storage,
@@ -270,14 +286,18 @@ export class TransformService {
         contentType = result.contentType;
         optimizationResult = result.optimizationResult;
       } else if (ext?.match(/mp4|mov|webm/)) {
-        const result = await this.processVideoFile(
-          sourcePath,
-          effectiveParams,
-          filePath,
-          cachePath,
-          sourcePath !== localPath
-        );
-        return result; // Video processing returns immediately
+        // Only thumbnail requests reach this point (non-thumbnail video
+        // transformations are intercepted before prepareSourceFile above);
+        // thumbnails are extracted synchronously like images
+        const result = await processVideo(sourcePath, effectiveParams);
+        return {
+          buffer: result.buffer,
+          contentType: result.contentType,
+          headers: {
+            'Content-Length': result.buffer.length.toString(),
+            'Cache-Control': 'public, max-age=31536000, must-revalidate',
+          },
+        };
       } else {
         throw new Error('Unsupported file type');
       }
@@ -356,52 +376,13 @@ export class TransformService {
   }
 
   /**
-   * Process video file (including job queue management)
-   */
-  private async processVideoFile(
-    sourcePath: string,
-    params: any,
-    filePath: string,
-    cachePath: string,
-    isTempFile?: boolean
-  ): Promise<TransformResult> {
-    // Check if this is a thumbnail extraction
-    const isThumbnailRequest =
-      params.thumbnail === 'true' || params.thumbnail === '1';
-
-    // For thumbnail extraction: process synchronously
-    if (isThumbnailRequest) {
-      const result = await processVideo(sourcePath, params);
-
-      return {
-        buffer: result.buffer,
-        contentType: result.contentType,
-        headers: {
-          'Content-Length': result.buffer.length.toString(),
-          'Cache-Control': 'public, max-age=31536000, must-revalidate',
-        },
-      };
-    }
-
-    // For video transformations: handle job queue
-    return await this.handleVideoJobQueue(
-      sourcePath,
-      params,
-      filePath,
-      cachePath,
-      isTempFile
-    );
-  }
-
-  /**
    * Handle video job queue management
    */
   private async handleVideoJobQueue(
-    sourcePath: string,
-    params: any,
     filePath: string,
-    cachePath: string,
-    isTempFile?: boolean
+    localPath: string,
+    params: any,
+    cachePath: string
   ): Promise<TransformResult> {
     // Check if already being processed
     let existingJob = videoJobQueue.getJobByPath(filePath, params);
@@ -424,10 +405,6 @@ export class TransformService {
           // Cache exists, try to serve from local cache first
           const cachedBuffer = await checkLocalCache(cachePath);
           if (cachedBuffer) {
-            if (isTempFile) {
-              await cleanupTempFile(sourcePath);
-            }
-
             return {
               buffer: cachedBuffer,
               contentType: `video/${filePath.split('.').pop()}`,
@@ -471,7 +448,7 @@ export class TransformService {
           filePath,
           params,
           cachePath,
-          sourcePath,
+          localPath,
           this.storage,
           TRANSFORMATION_PRIORITY
         )
@@ -480,34 +457,49 @@ export class TransformService {
         });
     }
 
-    // Return original video immediately
-    try {
-      const originalBuffer = this.storage
-        ? await this.storage.downloadOriginal(filePath)
-        : await readFile(`./public/${filePath}`);
+    // Stream the original video immediately, without buffering it in memory:
+    // originals can weigh hundreds of MB and buffering both delays the first
+    // byte and pressures the container memory while ffmpeg jobs are running
+    const processingHeaders: Record<string, string> = {
+      'X-Video-Status': 'processing',
+      'X-Original-Video': 'true',
+      'Cache-Control': 'public, max-age=0, must-revalidate',
+      ETag: `"${filePath}-processing-${Date.now()}"`,
+      Vary: 'Accept',
+    };
 
-      // Clean up temp file if needed
-      if (isTempFile && sourcePath !== `./public/${filePath}`) {
-        await cleanupTempFile(sourcePath);
+    try {
+      if (this.storage) {
+        const { stream, contentLength } =
+          await this.storage.downloadOriginalStream(filePath);
+        if (contentLength) {
+          processingHeaders['Content-Length'] = contentLength.toString();
+        }
+
+        return {
+          stream,
+          contentType: `video/${filePath.split('.').pop()}`,
+          headers: processingHeaders,
+          isProcessing: true,
+        };
       }
 
+      const { createReadStream } = await import('fs');
+      const { stat } = await import('fs/promises');
+      const stats = await stat(localPath);
+      processingHeaders['Content-Length'] = stats.size.toString();
+      const { Readable } = await import('stream');
+
       return {
-        buffer: originalBuffer,
+        stream: Readable.toWeb(
+          createReadStream(localPath)
+        ) as ReadableStream<Uint8Array>,
         contentType: `video/${filePath.split('.').pop()}`,
-        headers: {
-          'X-Video-Status': 'processing',
-          'X-Original-Video': 'true',
-          'Cache-Control': 'public, max-age=0, must-revalidate',
-          ETag: `"${filePath}-processing-${Date.now()}"`,
-          Vary: 'Accept',
-        },
+        headers: processingHeaders,
         isProcessing: true,
       };
     } catch (error) {
       logger.error({ error: serializeError(error), filePath }, 'Failed to serve original video');
-      if (isTempFile) {
-        await cleanupTempFile(sourcePath);
-      }
       throw new Error('Failed to load video');
     }
   }

--- a/apps/api/src/utils/storage/cloud-storage.ts
+++ b/apps/api/src/utils/storage/cloud-storage.ts
@@ -199,6 +199,20 @@ export class CloudStorage {
   }
 
   /**
+   * Retrieves an original (unprocessed) file as a stream, without buffering
+   * it in memory. Used to serve large originals (e.g. videos still being
+   * optimized) directly to clients.
+   */
+  async downloadOriginalStream(originalPath: string): Promise<{
+    stream: ReadableStream<Uint8Array>;
+    contentLength?: number;
+    contentType?: string;
+  }> {
+    const storageKey = `public/${originalPath}`;
+    return await this.s3Client.downloadObjectStream(storageKey);
+  }
+
+  /**
    * Uploads an original (unprocessed) file to the bucket
    */
   async uploadOriginal(

--- a/apps/api/src/utils/storage/s3-client.ts
+++ b/apps/api/src/utils/storage/s3-client.ts
@@ -104,6 +104,33 @@ export class S3ClientWrapper {
   }
 
   /**
+   * Downloads an object as a stream, without buffering it in memory.
+   * Used to serve large files (e.g. original videos) directly to clients.
+   */
+  async downloadObjectStream(key: string): Promise<{
+    stream: ReadableStream<Uint8Array>;
+    contentLength?: number;
+    contentType?: string;
+  }> {
+    const response = await this.s3Client.send(
+      new GetObjectCommand({
+        Bucket: this.config.bucketName,
+        Key: key,
+      }),
+    );
+
+    if (!response.Body) {
+      throw new Error("File not found");
+    }
+
+    return {
+      stream: response.Body.transformToWebStream() as ReadableStream<Uint8Array>,
+      contentLength: response.ContentLength,
+      contentType: response.ContentType,
+    };
+  }
+
+  /**
    * Lists objects under an optional prefix
    */
   async listObjects(

--- a/apps/api/src/utils/video/command-builder.ts
+++ b/apps/api/src/utils/video/command-builder.ts
@@ -1,6 +1,7 @@
 import ffmpeg, { FfmpegCommand } from 'fluent-ffmpeg';
 import { readFile, unlink, rmdir } from 'fs/promises';
 import type { VideoContext, TransformFunction } from './types';
+import { FFMPEG_THREADS, FFMPEG_NICENESS } from './config';
 
 /**
  * Builder class for constructing and executing ffmpeg commands
@@ -12,9 +13,12 @@ export class VideoCommandBuilder {
 
   constructor(context: VideoContext) {
     this.context = context;
-    this.command = ffmpeg(context.inputPath)
+    // niceness lowers ffmpeg's scheduling priority so encoding never starves
+    // the HTTP event loop; threads are capped to the container's effective
+    // CPUs (leaving one for serving) instead of a hardcoded value
+    this.command = ffmpeg(context.inputPath, { niceness: FFMPEG_NICENESS })
       .output(context.outputPath)
-      .addOption('-threads', '4'); // Increased to 4 threads for better performance
+      .addOption('-threads', String(FFMPEG_THREADS));
 
     // -movflags and -max_muxing_queue_size are MOV/MP4 container options and are
     // incompatible with image output formats (image2 muxer used for thumbnails).

--- a/apps/api/src/utils/video/config.ts
+++ b/apps/api/src/utils/video/config.ts
@@ -11,6 +11,10 @@ const CGROUP_V1_LIMIT_PATH = "/sys/fs/cgroup/memory/memory.limit_in_bytes";
 // cgroup v1 reports this (or similar huge values) when no limit is set
 const CGROUP_V1_UNLIMITED_THRESHOLD = 1e18;
 
+const CGROUP_V2_CPU_MAX_PATH = "/sys/fs/cgroup/cpu.max";
+const CGROUP_V1_CPU_QUOTA_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us";
+const CGROUP_V1_CPU_PERIOD_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_period_us";
+
 /**
  * Read the container memory limit from cgroup v2 or v1, if present.
  * Returns null when no cgroup file is found or the limit is "unlimited".
@@ -51,31 +55,105 @@ function getEffectiveMemoryBytes(): { bytes: number; source: "cgroup limit" | "h
 }
 
 /**
- * Detect optimal number of concurrent video jobs based on available memory
- * Formula: 1 worker per 2GB of memory (minimum 1, maximum 16)
+ * Read the container CPU limit from cgroup v2 or v1, if present.
+ * Returns the number of CPUs as a float (e.g. 0.5, 2), or null when
+ * no cgroup file is found or the limit is "unlimited".
  */
-function detectOptimalConcurrency(memoryBytes: number): number {
+function readCgroupCpuLimit(): number | null {
+  try {
+    // cgroup v2 format: "<quota> <period>" or "max <period>"
+    const raw = fs.readFileSync(CGROUP_V2_CPU_MAX_PATH, "utf8").trim();
+    const [quotaRaw, periodRaw] = raw.split(/\s+/);
+    if (quotaRaw === "max") return null;
+    const quota = parseInt(quotaRaw, 10);
+    const period = parseInt(periodRaw, 10);
+    if (Number.isFinite(quota) && Number.isFinite(period) && quota > 0 && period > 0) {
+      return quota / period;
+    }
+    return null;
+  } catch {
+    // cgroup v2 file not present, fall through to v1
+  }
+
+  try {
+    // cgroup v1 reports quota -1 when no limit is set
+    const quota = parseInt(fs.readFileSync(CGROUP_V1_CPU_QUOTA_PATH, "utf8").trim(), 10);
+    const period = parseInt(fs.readFileSync(CGROUP_V1_CPU_PERIOD_PATH, "utf8").trim(), 10);
+    if (Number.isFinite(quota) && Number.isFinite(period) && quota > 0 && period > 0) {
+      return quota / period;
+    }
+  } catch {
+    // cgroup v1 file not present either
+  }
+
+  return null;
+}
+
+/**
+ * Effective CPU count available to the process: the lower of the host CPUs
+ * and the container's cgroup CPU quota (if one is set), floored to at least 1.
+ */
+function getEffectiveCpuCount(): { count: number; source: "cgroup limit" | "host CPUs" } {
+  const cgroupLimit = readCgroupCpuLimit();
+  const hostCpus = os.cpus().length;
+  if (cgroupLimit !== null && cgroupLimit < hostCpus) {
+    return { count: Math.max(1, Math.floor(cgroupLimit)), source: "cgroup limit" };
+  }
+  return { count: hostCpus, source: "host CPUs" };
+}
+
+/**
+ * Detect optimal number of concurrent video jobs based on available resources.
+ * Memory: 1 worker per 2GB. CPU: at most 1 worker per effective CPU, so
+ * concurrent ffmpeg processes can never oversubscribe the container.
+ * Minimum 1, maximum 16.
+ */
+function detectOptimalConcurrency(memoryBytes: number, cpuCount: number): number {
   const memoryGB = memoryBytes / (1024 ** 3);
-  const optimal = Math.max(1, Math.floor(memoryGB / 2));
+  const byMemory = Math.max(1, Math.floor(memoryGB / 2));
   // Cap at 16 workers to prevent excessive resource usage
-  return Math.min(optimal, 16);
+  return Math.max(1, Math.min(byMemory, cpuCount, 16));
 }
 
 const { bytes: effectiveMemoryBytes, source: memorySource } = getEffectiveMemoryBytes();
+const { count: effectiveCpuCount, source: cpuSource } = getEffectiveCpuCount();
+
+/**
+ * Effective CPU count (host CPUs or cgroup quota, whichever is lower)
+ */
+export const EFFECTIVE_CPU_COUNT = effectiveCpuCount;
+
+/**
+ * Number of threads each ffmpeg process may use.
+ * Leaves one CPU free for the HTTP serving event loop so video jobs never
+ * starve the API, or configured via VIDEO_FFMPEG_THREADS env variable.
+ */
+export const FFMPEG_THREADS = process.env.VIDEO_FFMPEG_THREADS
+  ? Math.max(1, parseInt(process.env.VIDEO_FFMPEG_THREADS, 10) || 1)
+  : Math.max(1, effectiveCpuCount - 1);
+
+/**
+ * Niceness applied to spawned ffmpeg processes (0-19, higher = lower priority).
+ * Keeps the Node event loop responsive even when ffmpeg saturates the CPU.
+ * Configurable via VIDEO_FFMPEG_NICENESS env variable.
+ */
+export const FFMPEG_NICENESS = process.env.VIDEO_FFMPEG_NICENESS
+  ? parseInt(process.env.VIDEO_FFMPEG_NICENESS, 10)
+  : 15;
 
 /**
  * Maximum number of concurrent video jobs
- * Auto-detected based on available memory (host RAM or cgroup limit, whichever is
- * lower), or configured via VIDEO_MAX_CONCURRENT env variable
+ * Auto-detected based on available memory and CPU (host or cgroup limit,
+ * whichever is lower), or configured via VIDEO_MAX_CONCURRENT env variable
  */
 export const MAX_CONCURRENT_JOBS = process.env.VIDEO_MAX_CONCURRENT
   ? parseInt(process.env.VIDEO_MAX_CONCURRENT, 10)
-  : detectOptimalConcurrency(effectiveMemoryBytes);
+  : detectOptimalConcurrency(effectiveMemoryBytes, effectiveCpuCount);
 
 // Log detected configuration on module load
 const effectiveMemoryGB = (effectiveMemoryBytes / (1024 ** 3)).toFixed(2);
-const configSource = process.env.VIDEO_MAX_CONCURRENT ? "env variable" : memorySource;
-console.log(`[Video Config] Memory: ${effectiveMemoryGB}GB (${memorySource}) | Max concurrent jobs: ${MAX_CONCURRENT_JOBS} (${configSource})`);
+const configSource = process.env.VIDEO_MAX_CONCURRENT ? "env variable" : `${memorySource}, ${cpuSource}`;
+console.log(`[Video Config] Memory: ${effectiveMemoryGB}GB (${memorySource}) | CPUs: ${effectiveCpuCount} (${cpuSource}) | Max concurrent jobs: ${MAX_CONCURRENT_JOBS} (${configSource}) | ffmpeg threads: ${FFMPEG_THREADS}, niceness: ${FFMPEG_NICENESS}`);
 
 /**
  * Maximum number of retry attempts for failed jobs


### PR DESCRIPTION
## Summary

Freshly uploaded videos were unreachable (page loading indefinitely) until the background optimization job finished. Two combined root causes on resource-constrained containers (e.g. Railway 1-2 vCPU):

- **CPU oversubscription**: ffmpeg used `-threads 4` hardcoded, and job concurrency was derived from RAM only (2 vCPU / 8GB → 4 concurrent jobs × 4 threads = 16 encoding threads on 2 cores), starving the Node event loop at equal scheduling priority.
- **Redundant buffering**: serving the original video during processing buffered the whole file in memory, and downloaded it twice (a temp copy via `prepareSourceFile`, then a second `downloadOriginal`), delaying the first byte by the full transfer time — doubled.

## Changes

- Detect effective CPU count from cgroup (`cpu.max` v2 / `cfs_quota_us` v1), mirroring the existing memory-based detection.
- Cap ffmpeg `-threads` to `effectiveCPUs - 1` (leaves one core for HTTP serving), overridable via `VIDEO_FFMPEG_THREADS`.
- Bound `MAX_CONCURRENT_JOBS` by CPU count in addition to RAM.
- Spawn ffmpeg at niceness 15 (`VIDEO_FFMPEG_NICENESS`) so encoding yields to the event loop under saturation.
- Stream the original video (S3 `GetObject` stream or local file stream) instead of buffering it, with `Content-Length` set from the source. Video transformation jobs no longer trigger the unnecessary `prepareSourceFile` download (the background worker fetches its own copy).

## Test plan

- [x] `pnpm --filter api type-check` and `pnpm --filter api test` pass
- [x] Verified cgroup detection inside a `docker run --cpus=2 --memory=8g` container: resolves to `CPUs: 2, threads: 1, max jobs: 2` (vs. 4 jobs × 4 threads before)
- [x] End-to-end locally: `/t/video.mp4` responds in ~8ms with `X-Video-Status: processing` and a byte-identical stream to the original while a job is running; live ffmpeg process observed running at `nice 15`; after job completion, same URL serves the optimized version with `X-Video-Status: ready`

🤖 Generated with [Claude Code](https://claude.com/claude-code)