### PR TITLE
feat(web): add appearance settings with thumbnail hiding option

### DIFF
--- a/apps/web/src/components/media-grid.tsx
+++ b/apps/web/src/components/media-grid.tsx
@@ -4,6 +4,7 @@ import type React from "react";
 import { useState, useMemo, useEffect, useRef } from "react";
 import {
   FileImage,
+  FileVideo,
   ArrowUpRight,
   Check,
   Copy,
@@ -22,6 +23,7 @@ import { useQueryState } from "nuqs";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useStorageTree } from "@/hooks/use-storage-tree";
+import { useHideThumbnails } from "@/hooks/use-hide-thumbnails";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import {
@@ -83,6 +85,26 @@ const MIME_TYPES: Record<string, string> = {
 function getMimeType(name: string): string {
   const ext = name.split(".").pop()?.toLowerCase() || "";
   return MIME_TYPES[ext] || ext;
+}
+
+function FileTypeIcon({
+  type,
+  className,
+}: {
+  type: "image" | "video";
+  className?: string;
+}) {
+  const Icon = type === "video" ? FileVideo : FileImage;
+  return (
+    <div
+      className={cn(
+        "flex h-full w-full items-center justify-center bg-muted/30",
+        className,
+      )}
+    >
+      <Icon className="h-1/3 w-1/3 text-muted-foreground" strokeWidth={1.5} />
+    </div>
+  );
 }
 
 function formatListSize(bytes?: number): string {
@@ -269,6 +291,7 @@ export function MediaGrid({
   view = "grid",
 }: MediaGridProps) {
   const { data: treeData, isLoading, error } = useStorageTree();
+  const [hideThumbnails] = useHideThumbnails();
   const queryClient = useQueryClient();
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
@@ -931,9 +954,11 @@ export function MediaGrid({
                 const itemCount = treeData
                   ? getFolderItemCount(treeData, [...pathSegments, folder.name])
                   : 0;
-                const previewItems = treeData
-                  ? getFolderPreviewItems(treeData, [...pathSegments, folder.name])
-                  : [];
+                const previewItems = hideThumbnails
+                  ? []
+                  : treeData
+                    ? getFolderPreviewItems(treeData, [...pathSegments, folder.name])
+                    : [];
                 const renderPreview = (
                   item: { path: string; type: "image" | "video" },
                   size: "square" | "tall" | "large",
@@ -1022,9 +1047,30 @@ export function MediaGrid({
                             </div>
                           )}
                         </div>
-                        <div className="absolute inset-x-0 bottom-0 max-w-full bg-gradient-to-t from-black/80 via-black/40 to-transparent p-3 text-left">
-                          <p className="text-sm font-medium text-white truncate">{folder.name}</p>
-                          <p className="text-xs text-white/70">
+                        <div
+                          className={cn(
+                            "absolute inset-x-0 bottom-0 max-w-full p-3 text-left",
+                            hideThumbnails
+                              ? ""
+                              : "bg-gradient-to-t from-black/80 via-black/40 to-transparent",
+                          )}
+                        >
+                          <p
+                            className={cn(
+                              "text-sm font-medium truncate",
+                              hideThumbnails ? "text-foreground" : "text-white",
+                            )}
+                          >
+                            {folder.name}
+                          </p>
+                          <p
+                            className={cn(
+                              "text-xs",
+                              hideThumbnails
+                                ? "text-muted-foreground"
+                                : "text-white/70",
+                            )}
+                          >
                             {itemCount} {itemCount === 1 ? "item" : "items"}
                           </p>
                         </div>
@@ -1124,7 +1170,9 @@ export function MediaGrid({
                               }
                             />
                           </div>
-                          {media.type === "image" ? (
+                          {hideThumbnails ? (
+                            <FileTypeIcon type={media.type} />
+                          ) : media.type === "image" ? (
                             <img
                               src={thumbnailUrl}
                               alt={media.name}
@@ -1141,11 +1189,19 @@ export function MediaGrid({
                           )}
                           <div
                             className={cn(
-                              "absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent p-2 transition-opacity",
+                              "absolute inset-x-0 bottom-0 p-2 transition-opacity",
+                              hideThumbnails
+                                ? ""
+                                : "bg-gradient-to-t from-black/80 via-black/40 to-transparent",
                               isHovered ? "opacity-100" : "opacity-0",
                             )}
                           >
-                            <p className="text-white text-xs font-medium truncate">
+                            <p
+                              className={cn(
+                                "text-xs font-medium truncate",
+                                hideThumbnails ? "text-foreground" : "text-white",
+                              )}
+                            >
                               {media.name}
                             </p>
                           </div>
@@ -1257,7 +1313,9 @@ export function MediaGrid({
                               });
                             }}
                           >
-                            {media.type === "image" ? (
+                            {hideThumbnails ? (
+                              <FileTypeIcon type={media.type} />
+                            ) : media.type === "image" ? (
                               <img
                                 src={thumbnailUrl}
                                 alt={media.name}

--- a/apps/web/src/components/sidebar/appearance-tab.tsx
+++ b/apps/web/src/components/sidebar/appearance-tab.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Laptop, Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { useHideThumbnails } from "@/hooks/use-hide-thumbnails";
+
+const THEME_OPTIONS = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Laptop },
+] as const;
+
+export function AppearanceTab() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const [hideThumbnails, setHideThumbnails] = useHideThumbnails();
+
+  // Avoid a hydration mismatch: next-themes only knows the resolved theme
+  // once mounted on the client.
+  useEffect(() => setMounted(true), []);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+        <div>
+          <p className="text-sm font-medium">Theme</p>
+          <p className="text-xs text-muted-foreground">
+            Pick a theme. &quot;System&quot; follows your OS appearance
+            setting and updates automatically when it changes.
+          </p>
+        </div>
+        <div className="flex shrink-0 gap-1 rounded-full border bg-muted/40 p-1">
+          {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setTheme(value)}
+              className={cn(
+                "flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm transition-colors",
+                mounted && theme === value
+                  ? "bg-foreground text-background"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <Icon className="size-4" />
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+        <div>
+          <p className="text-sm font-medium">Hide thumbnails</p>
+          <p className="text-xs text-muted-foreground">
+            Show a generic icon per file type or folder instead of a
+            thumbnail preview, for better performance in the dashboard. Grid
+            and list views are affected; the Asset Details sidebar still
+            shows the full preview.
+          </p>
+        </div>
+        <Switch
+          checked={hideThumbnails}
+          onCheckedChange={setHideThumbnails}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/sidebar/settings-dialog.tsx
+++ b/apps/web/src/components/sidebar/settings-dialog.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { HardDrive, KeyRound, User } from "lucide-react";
+import { HardDrive, KeyRound, Palette, User } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import { AccountTab } from "./account-tab";
 import { ApiKeysTab } from "./api-keys-tab";
+import { AppearanceTab } from "./appearance-tab";
 import { StorageTab } from "./storage-tab";
 
 interface SettingsDialogProps {
@@ -17,6 +18,7 @@ interface SettingsDialogProps {
 
 const SETTINGS_NAV = [
   { value: "account", label: "Account", icon: User },
+  { value: "appearance", label: "Appearance", icon: Palette },
   { value: "api-keys", label: "API Keys", icon: KeyRound },
   { value: "storage", label: "Storage", icon: HardDrive },
 ] as const;
@@ -74,6 +76,7 @@ export function SettingsDialog({
                 isOpen={dialogOpen && activeTab === "account"}
               />
             )}
+            {activeTab === "appearance" && <AppearanceTab />}
             {activeTab === "api-keys" && <ApiKeysTab />}
             {activeTab === "storage" && <StorageTab />}
           </div>

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import * as React from "react";
+import { Switch as SwitchPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer inline-flex h-5 w-9 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50",
+        "data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block size-4 rounded-full bg-background shadow-lg ring-0 transition-transform",
+          "data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0.5",
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/apps/web/src/hooks/use-hide-thumbnails.ts
+++ b/apps/web/src/hooks/use-hide-thumbnails.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "openinary:hide-thumbnails";
+const EVENT_NAME = "openinary:hide-thumbnails-change";
+
+function getSnapshot(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(STORAGE_KEY) === "true";
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+function subscribe(callback: () => void): () => void {
+  window.addEventListener(EVENT_NAME, callback);
+  window.addEventListener("storage", callback);
+  return () => {
+    window.removeEventListener(EVENT_NAME, callback);
+    window.removeEventListener("storage", callback);
+  };
+}
+
+export function useHideThumbnails(): [boolean, (value: boolean) => void] {
+  const hideThumbnails = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+
+  const setHideThumbnails = (value: boolean) => {
+    window.localStorage.setItem(STORAGE_KEY, String(value));
+    window.dispatchEvent(new Event(EVENT_NAME));
+  };
+
+  return [hideThumbnails, setHideThumbnails];
+}


### PR DESCRIPTION
## Summary
- Add an "Appearance" tab in the settings dialog
- Add a toggle to hide media thumbnails in the grid, showing file-type icons instead

## Test plan
- [x] Open Settings → Appearance tab is visible and functional
- [x] Toggle "hide thumbnails" and confirm grid switches to file-type icons for both images and videos
- [x] Confirm folder previews respect the setting
- [x] Confirm setting persists across reload