### PR TITLE
Initial ENV user configuration

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -50,7 +50,7 @@ videoJobQueue.initialize(getSharedStorage());
 // Initialize authentication and generate API key if needed (only in standalone mode)
 async function initializeAuth() {
   try {
-    const mode = process.env.MODE || "fullstack";
+    const mode = process.env.MODE?.toLowerCase().trim() || "fullstack";
     const db = auth.options.database;
     const users = db.prepare("SELECT COUNT(*) as count FROM user").get() as {
       count: number;
@@ -99,10 +99,10 @@ async function initializeAuth() {
 
     logger.info("Initial user created successfully!");
 
-    if (!generateApiKey)
+    if (!generateApiKey && mode === "fullstack")
       return logger.info(
         { userCount: users.count },
-        `Database initialized (${mode === "api" ? "API STANDALONE mode" : "FULLSTACK mode"})`,
+        `Database initialized (FULLSTACK mode)`,
       );
 
     // Create an API key for this user

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -56,69 +56,93 @@ async function initializeAuth() {
       count: number;
     };
 
-    // In fullstack mode, never create users automatically
-    if (mode === "fullstack") {
-      if (users.count === 0) {
-        logger.info(
-          "No users found. Please visit /setup to create your first admin account.",
-        );
-      } else {
-        logger.info(
-          { userCount: users.count },
-          "Database initialized (FULLSTACK mode)",
-        );
-      }
-      return;
-    }
-
-    // In API standalone mode, generate API key only (no exposed credentials)
-    if (users.count === 0) {
-      logger.info("Running in API STANDALONE mode");
-      logger.info("Generating initial API key...");
-
-      // Create a system user (required for API key association)
-      // This user is internal only - credentials are never exposed or used
-      const systemPassword = randomUUID() + randomUUID(); // Random, never shown
-      const signUpResult = await auth.api.signUpEmail({
-        body: {
-          email: "system@openinary.local",
-          password: systemPassword,
-          name: "System",
-        },
-      });
-
-      if (signUpResult) {
-        const userId = signUpResult.user.id;
-
-        // Create an API key for this user
-        const apiKeyResult = await auth.api.createApiKey({
-          body: {
-            name: "Initial API Key",
-            userId: userId,
-            expiresIn: 365 * 24 * 60 * 60, // 1 year in seconds
-          },
-        });
-
-        if (apiKeyResult && "key" in apiKeyResult) {
-          logger.info(
-            { apiKeyId: apiKeyResult.id },
-            "┌─────────────────────────────────────────────────────────────────┐\n│                  Initial API Key Generated                      │\n├─────────────────────────────────────────────────────────────────┤\n│                                                                 │\n│  API Key: " +
-              apiKeyResult.key +
-              "                                   │\n│                                                                 │\n│  Save this key now! It will not be shown again.                 │\n│                                                                 │\n└─────────────────────────────────────────────────────────────────┘",
-          );
-        }
-      }
-    } else {
-      logger.info(
+    if (users.count > 0)
+      return logger.info(
         { userCount: users.count },
-        "Database initialized (API STANDALONE mode)",
+        `Database initialized (${mode === "api" ? "API STANDALONE mode" : "FULLSTACK mode"})`,
+      );
+
+    const accName = process.env.OPENINARY_ADMIN_NAME?.trim();
+    const accEmail = process.env.OPENINARY_ADMIN_EMAIL?.trim();
+    const accPassword = process.env.OPENINARY_ADMIN_PASSWORD;
+    const generateApiKey =
+      process.env.OPENINARY_GENERATE_API_KEY?.trim() === "true";
+
+    if (mode === "fullstack" && !generateApiKey && !accEmail && !accPassword)
+      return logger.info(
+        "No users found. Please visit /setup to create your first admin account.",
+      );
+
+    if ((!accEmail && accPassword) || (accEmail && !accPassword))
+      throw new Error(
+        "You have to configure both admin email and password or none.",
+      );
+
+    if (mode === "fullstack" && generateApiKey && !accEmail)
+      throw new Error(
+        "In fullstack mode you have to also configure admin credentials for generating an API key on initialization.",
+      );
+
+    // Setup user and API key if configured
+    logger.info("Creating admin user...");
+
+    // Create a system user (because configured OR required for API key association)
+    const signUpResult = await auth.api.signUpEmail({
+      body: {
+        email: accEmail || "system@openinary.local",
+        password: accPassword || randomUUID() + randomUUID(),
+        name: accName || "Admin",
+      },
+    });
+
+    if (!signUpResult) throw new Error("Creating initial user failed.");
+
+    logger.info("Initial user created successfully!");
+
+    if (!generateApiKey)
+      return logger.info(
+        { userCount: users.count },
+        `Database initialized (${mode === "api" ? "API STANDALONE mode" : "FULLSTACK mode"})`,
+      );
+
+    // Create an API key for this user
+    const apiKeyResult = await auth.api.createApiKey({
+      body: {
+        name: "Initial API Key",
+        userId: signUpResult.user.id,
+        expiresIn: 365 * 24 * 60 * 60, // 1 year in seconds
+      },
+    });
+
+    if (!apiKeyResult || !("key" in apiKeyResult)) {
+      const deleteResult = db
+        .prepare(`DELETE FROM user WHERE id=${signUpResult.user.id}`)
+        .get() as {
+        rowsAffected: number;
+      };
+
+      if (deleteResult.rowsAffected === 0)
+        throw new Error(
+          "Initial API Key could not be generated. Deleting user for cleanup failed.",
+        );
+
+      throw new Error(
+        "Initial API Key could not be generated. User was removed again.",
       );
     }
-  } catch (error) {
-    logger.error(
-      { error: serializeError(error) },
-      "Error initializing authentication",
+
+    logger.info(
+      { apiKeyId: apiKeyResult.id },
+      "┌─────────────────────────────────────────────────────────────────┐\n│                  Initial API Key Generated                      │\n├─────────────────────────────────────────────────────────────────┤\n│                                                                 │\n│  API Key: " +
+        apiKeyResult.key +
+        "                                   │\n│                                                                 │\n│  Save this key now! It will not be shown again.                 │\n│                                                                 │\n└─────────────────────────────────────────────────────────────────┘",
     );
+    logger.info(
+      { userCount: users.count },
+      `Database initialized (${mode === "api" ? "API STANDALONE mode" : "FULLSTACK mode"})`,
+    );
+  } catch (error) {
+    logger.error({ error: serializeError(error) }, "Database setup failed.");
   }
 }
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -141,8 +141,9 @@ async function initializeAuth() {
       { userCount: users.count },
       `Database initialized (${mode === "api" ? "API STANDALONE mode" : "FULLSTACK mode"})`,
     );
-  } catch (error) {
-    logger.error({ error: serializeError(error) }, "Database setup failed.");
+  } catch (error: any) {
+    logger.error(error?.message || "Database setup failed.");
+    process.exit(0);
   }
 }
 
@@ -161,12 +162,7 @@ initTelemetry();
 
 // Initialize auth in background (non-blocking)
 // This allows the server to respond to healthchecks immediately
-initializeAuth().catch((error) => {
-  logger.error(
-    { error: serializeError(error) },
-    "Error during background auth initialization",
-  );
-});
+initializeAuth();
 
 // Graceful shutdown
 process.on("SIGTERM", () => {

--- a/apps/web/src/app/(dashboard)/page.tsx
+++ b/apps/web/src/app/(dashboard)/page.tsx
@@ -12,7 +12,7 @@ import { SidebarInset } from "@/components/ui/sidebar";
 import { Spinner } from "@/components/ui/spinner";
 import { useSession } from "@/lib/auth-client";
 import { MediaGrid, type MediaFile } from "@openinary/ui";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { parseAsString, useQueryState } from "nuqs";
 import { Suspense, useEffect, useRef, useState } from "react";
 import type { ImperativePanelHandle } from "react-resizable-panels";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,11 @@ services:
       - VIDEO_JOB_CLEANUP_HOURS=${VIDEO_JOB_CLEANUP_HOURS:-24}
       - VIDEO_WORKER_POLL_INTERVAL_MS=${VIDEO_WORKER_POLL_INTERVAL_MS:-1000}
       - MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
+      # Initial Authentication configuration
+      - OPENINARY_ADMIN_NAME=${OPENINARY_ADMIN_NAME}
+      - OPENINARY_ADMIN_EMAIL=${OPENINARY_ADMIN_EMAIL}
+      - OPENINARY_ADMIN_PASSWORD=${OPENINARY_ADMIN_PASSWORD}
+      - OPENINARY_GENERATE_API_KEY=${OPENINARY_GENERATE_API_KEY:-true}
     networks:
       - openinary-network
     # Resource limits to prevent video processing from crashing the server
@@ -91,6 +96,11 @@ services:
       - VIDEO_JOB_CLEANUP_HOURS=${VIDEO_JOB_CLEANUP_HOURS:-24}
       - VIDEO_WORKER_POLL_INTERVAL_MS=${VIDEO_WORKER_POLL_INTERVAL_MS:-1000}
       - MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-50}
+      # Initial Authentication configuration
+      - OPENINARY_ADMIN_NAME=${OPENINARY_ADMIN_NAME}
+      - OPENINARY_ADMIN_EMAIL=${OPENINARY_ADMIN_EMAIL}
+      - OPENINARY_ADMIN_PASSWORD=${OPENINARY_ADMIN_PASSWORD}
+      - OPENINARY_GENERATE_API_KEY=${OPENINARY_GENERATE_API_KEY:-false}
     networks:
       - openinary-network
     # Resource limits to prevent video processing from crashing the server

--- a/docker.env.example
+++ b/docker.env.example
@@ -39,6 +39,17 @@ BETTER_AUTH_URL=http://localhost:3000
 # Generate a 64-character secret: openssl rand -hex 32
 API_SECRET=your-secret-here-64-chars
 
+# Initial account setup credentials and api generation (optional)
+# An API key is always generated when first launch happenes in API mode.
+# Initial gernerated API keys are only valid for 1 year.
+#
+# make sure to REMOVE these again after first launch
+#
+# OPENINARY_ADMIN_NAME=adminname
+# OPENINARY_ADMIN_EMAIL=your@email.com
+# OPENINARY_ADMIN_PASSWORD=your-secure-password
+# OPENINARY_GENERATE_API_KEY=true
+
 # ============================================
 # Accessibility (Optional)
 # ============================================


### PR DESCRIPTION
**Hey,**
I thought I would add the option to create a user on first start up by setting additional ENVs.
Furthermore I also added the option to directly generate an API Key which is always generated when launching in API mode. Also in this case the user can pass user credentions so they are able to login when changing the mode to FULLSTACK later.

### Added ENVs:
- OPENINARY_ADMIN_NAME
- OPENINARY_ADMIN_EMAIL
- OPENINARY_ADMIN_PASSWORD
- OPENINARY_GENERATE_API_KEY

Closes #84