### PR TITLE
fix(ui): stop tabs indicator lagging on container resize

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openinary/ui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Openinary's dashboard UI components, hooks and design primitives as a standalone, embeddable React package.",
   "type": "module",
   "license": "AGPL-3.0-only",

--- a/packages/ui/src/ui/tabs.tsx
+++ b/packages/ui/src/ui/tabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+import * as React from "react";
 
 import { cn } from "../lib/utils";
 
@@ -27,8 +28,34 @@ function TabsList({
 }: TabsPrimitive.List.Props & {
   variant?: TabsVariant;
 }) {
+  const listRef = React.useRef<HTMLDivElement>(null);
+
+  // The indicator is positioned from measured CSS vars, so a resize would
+  // animate toward the new position instead of tracking it. Skip the
+  // transition while the list is being resized.
+  React.useEffect(() => {
+    const el = listRef.current;
+    if (!el) return;
+
+    let timer: ReturnType<typeof setTimeout>;
+    const observer = new ResizeObserver(() => {
+      el.dataset.resizing = "";
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        delete el.dataset.resizing;
+      }, 100);
+    });
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+      clearTimeout(timer);
+    };
+  }, []);
+
   return (
     <TabsPrimitive.List
+      ref={listRef}
       className={cn(
         "relative z-0 flex w-fit items-center justify-center gap-x-0.5 text-muted-foreground",
         "data-[orientation=vertical]:flex-col",
@@ -43,7 +70,7 @@ function TabsList({
       {children}
       <TabsPrimitive.Indicator
         className={cn(
-          "-translate-y-(--active-tab-bottom) absolute bottom-0 left-0 h-(--active-tab-height) w-(--active-tab-width) translate-x-(--active-tab-left) transition-[width,translate] duration-200 ease-in-out",
+          "-translate-y-(--active-tab-bottom) absolute bottom-0 left-0 h-(--active-tab-height) w-(--active-tab-width) translate-x-(--active-tab-left) transition-[width,translate] duration-200 ease-in-out [[data-resizing]_&]:transition-none",
           variant === "underline"
             ? "data-[orientation=vertical]:-translate-x-px z-10 bg-primary data-[orientation=horizontal]:h-0.5 data-[orientation=vertical]:w-0.5 data-[orientation=horizontal]:translate-y-px"
             : "-z-1 rounded-md bg-background shadow-sm dark:bg-input",


### PR DESCRIPTION
## Problem

Resizing the Asset Details panel made the background behind the active tab (Details / Transformations / Metadata) resize jerkily and lag behind the tab.

## Cause

`TabsIndicator` is positioned from `--active-tab-width` / `--active-tab-left`, which base-ui re-measures with a `ResizeObserver`. Our class carries `transition-[width,translate] duration-200`, so every resize frame *animated* toward the new measurement instead of tracking it — hence the lag and the stutter.

## Fix

A `ResizeObserver` on the list flags `data-resizing` while a resize is in flight and clears it 100 ms after the last frame; the indicator drops its transition under that flag. Tab switches still slide as before.

Also bumps `@openinary/ui` to 0.4.1.

## Testing

`tsc --noEmit` passes on `packages/ui`. Not verified in a running browser — the fix is CSS-level and only observable mid-drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)