### PR TITLE
fix(core): reject output formats no encoder can produce

### DIFF
--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -9,6 +9,7 @@ import {
   TRANSFORMATION_PRIORITY,
   TransformService,
   generateUploadSignature,
+  validateUploadFileType,
   logger,
   serializeError,
   type RouteDeps,
@@ -26,24 +27,6 @@ const MAX_PREWARM_TRANSFORMATIONS = 20;
 // Presigned upload token lifetime, in seconds
 const DEFAULT_PRESIGN_EXPIRES_IN = 5 * 60; // 5 minutes
 const MAX_PRESIGN_EXPIRES_IN = 60 * 60; // 1 hour
-
-// Allowed file extensions and MIME types
-const ALLOWED_TYPES = {
-  // Images
-  "image/jpeg": [".jpg", ".jpeg"],
-  "image/png": [".png"],
-  "image/webp": [".webp"],
-  "image/avif": [".avif"],
-  "image/gif": [".gif"],
-  "image/heic": [".heic", ".heif"],
-  "image/heif": [".heic", ".heif"],
-  "image/vnd.adobe.photoshop": [".psd"],
-  "application/octet-stream": [".psd"],
-  // Videos
-  "video/mp4": [".mp4"],
-  "video/quicktime": [".mov"],
-  "video/webm": [".webm"],
-};
 
 interface UploadResult {
   filename: string;
@@ -214,21 +197,6 @@ export function createUploadRoute(deps: RouteDeps) {
     sanitized = sanitized.replace(/\/+/g, "/"); // Multiple slashes
 
     return sanitized;
-  }
-
-  /**
-   * Validates file type based on MIME type and extension
-   */
-  function validateFileType(filename: string, mimeType: string): boolean {
-    const ext = path.extname(filename).toLowerCase();
-    const allowedExtensions =
-      ALLOWED_TYPES[mimeType as keyof typeof ALLOWED_TYPES];
-
-    if (!allowedExtensions) {
-      return false;
-    }
-
-    return allowedExtensions.includes(ext);
   }
 
   /**
@@ -509,7 +477,7 @@ export function createUploadRoute(deps: RouteDeps) {
         }
 
         // Validate file type
-        if (!validateFileType(filename, mimeType)) {
+        if (!validateUploadFileType(filename, mimeType)) {
           failedUploads.push({
             filename: rawSanitizedPath,
             error: `Invalid file type: ${mimeType}. Allowed types: images (jpg, jpeg, png, webp, avif, gif, heic, heif, psd) and videos (mp4, mov, webm)`,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openinary/core",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Openinary's media transformation engine and route handlers (image/video processing, storage, job queue) as a standalone, embeddable package.",
   "type": "module",
   "license": "AGPL-3.0-only",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,5 +53,6 @@ export { getCachePath } from "./utils/cache";
 export { parseParams } from "./utils/parser";
 export { validateApiSecret } from "./utils/signature";
 export { generateUploadSignature, verifyUploadSignature } from "./utils/upload-signature";
+export { ALLOWED_UPLOAD_TYPES, validateUploadFileType } from "./utils/upload-validation";
 export { deleteAssetCompletely, type DeleteAssetResult } from "./utils/asset-deletion";
 export { default as logger, serializeError } from "./utils/logger";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,7 +7,14 @@ export type GravityMode =
   | "west"
   | "face"
   | "auto";
-export type ImageFormat = "avif" | "webp" | "jpeg" | "jpg" | "png" | "auto";
+export type ImageFormat =
+  | "avif"
+  | "webp"
+  | "jpeg"
+  | "jpg"
+  | "png"
+  | "gif"
+  | "auto";
 export type VideoFormat = "mp4" | "mov" | "webm";
 
 export interface BackgroundColor {

--- a/packages/core/src/utils/format-support.test.ts
+++ b/packages/core/src/utils/format-support.test.ts
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isTransformSegment, parseParams } from "./parser";
+import { IMAGE_FORMATS, VIDEO_FORMATS, determineOutputFormat } from "./video/format";
+
+// The f_ parameter is the trust boundary: every value it lets through must be a
+// format some encoder can actually produce, otherwise we serve bytes of one
+// format under the content-type of another.
+
+test("f_ accepts only encodable output formats", () => {
+  for (const f of ["webp", "jpg", "jpeg", "png", "avif", "gif", "mp4", "webm", "mov", "auto"]) {
+    assert.ok(isTransformSegment(`f_${f}`), `${f} should be accepted`);
+  }
+});
+
+test("f_ rejects formats no encoder produces", () => {
+  // psd is an accepted upload format but never an output; the rest were never
+  // wired to any encoder and silently fell back to png/mp4.
+  for (const f of ["psd", "avi", "mp3", "wav", "ogg", "pdf", "tiff"]) {
+    assert.ok(!isTransformSegment(`f_${f}`), `${f} should be rejected`);
+  }
+});
+
+test("every f_ value maps to a real image or video output format", () => {
+  const encodable = new Set([...IMAGE_FORMATS, ...VIDEO_FORMATS, "auto"]);
+  for (const f of ["webp", "jpg", "jpeg", "png", "avif", "gif", "mp4", "webm", "mov", "auto"]) {
+    const { format } = parseParams(`/t/f_${f}/x.jpg`);
+    assert.ok(encodable.has(format), `${f} parsed to unencodable ${format}`);
+  }
+});
+
+test("video thumbnails resolve to an image format, video transforms to a video one", () => {
+  assert.deepEqual(determineOutputFormat("mp4", "webp"), {
+    format: "webp",
+    isImageOutput: true,
+    isThumbnail: true,
+  });
+  assert.equal(determineOutputFormat("mp4", "webm").format, "webm");
+  // psd is no longer an image output, so it can't produce a bogus image/psd
+  assert.equal(determineOutputFormat("mp4", "psd").isImageOutput, false);
+});

--- a/packages/core/src/utils/image/compression.ts
+++ b/packages/core/src/utils/image/compression.ts
@@ -3,6 +3,11 @@ import { TransformParams, ImageFormat, ImageAnalysis, OptimizationResult } from 
 import logger, { serializeError } from '../logger';
 
 export class Compression {
+  /** Formats applyFormat() can actually encode. Excludes "auto". */
+  private static readonly ENCODABLE_FORMATS = new Set<string>([
+    'avif', 'webp', 'jpeg', 'jpg', 'png', 'gif'
+  ]);
+
   private static readonly FORMAT_PRIORITIES = {
     avif: { quality: 0.9, savings: 0.7 },  // AVIF: Excellent compression, slightly lower quality acceptable
     webp: { quality: 0.95, savings: 0.6 }, // WebP: Good compression, high quality
@@ -29,8 +34,10 @@ export class Compression {
     const metadata = await sharp(inputPath).metadata();
     
     // If format is explicitly specified, use it directly (no size comparison needed)
-    // "auto" is not an explicit format — it falls through to format size comparison below
-    if (params.format && params.format !== 'auto') {
+    // "auto" is not an explicit format — it falls through to format size comparison below.
+    // A video format requested on an image source (f_mp4 on a .jpg) also falls
+    // through rather than being mislabelled as image/mp4 with PNG bytes.
+    if (params.format && Compression.ENCODABLE_FORMATS.has(params.format)) {
       const explicitFormat = params.format === 'jpg' ? 'jpeg' : params.format;
       const userQuality = params.quality ? parseInt(String(params.quality)) : undefined;
       const optimalQuality = this.calculateOptimalQuality(
@@ -238,10 +245,13 @@ export class Compression {
         
       case 'png':
         return pipeline.png({
-          compressionLevel: 3, 
-          adaptiveFiltering: false 
+          compressionLevel: 3,
+          adaptiveFiltering: false
         });
-        
+
+      case 'gif':
+        return pipeline.gif();
+
       default:
         // PNG fallback
         return pipeline.png({

--- a/packages/core/src/utils/parser.ts
+++ b/packages/core/src/utils/parser.ts
@@ -25,7 +25,10 @@ const TRANSFORM_VALUE_PATTERNS: Readonly<Record<string, RegExp>> = {
   c:  /^(fill|lfill|fill_pad|fit|limit|mfit|scale|crop|thumb|pad|lpad)$/,
   g:  /^(center|c|north(?:_center)?|n|south(?:_center)?|s|east|e|west|w|faces?(?:_center)?|auto)$/,
   q:  /^\d+$|^auto$/,
-  f:  /^(webp|jpe?g|png|avif|gif|psd|mp4|webm|mov|avi|mp3|wav|ogg|pdf|auto)$/,
+  // Only formats an encoder can actually produce. Image sources: webp/jpeg/png/
+  // avif/gif via sharp. Video sources: mp4/webm/mov, plus the image formats as
+  // thumbnails. psd is an accepted *upload* format but is never an output.
+  f:  /^(webp|jpe?g|png|avif|gif|mp4|webm|mov|auto)$/,
   a:  /^-?\d+$|^auto$/,
   ar: /^\d+:\d+$|^\d+(?:\.\d+)?$/,
   b:  /^(transparent|white|black|rgb:[0-9a-fA-F]{3,8}|#?[0-9a-fA-F]{3,8})$/,

--- a/packages/core/src/utils/upload-validation.ts
+++ b/packages/core/src/utils/upload-validation.ts
@@ -1,0 +1,41 @@
+import path from "path";
+
+/**
+ * Single source of truth for what Openinary accepts at upload time.
+ * Consumed by the OSS API and the SaaS so their whitelists cannot diverge.
+ *
+ * Deliberately excludes svg (stored-XSS vector when served inline) and every
+ * format the transform pipeline cannot decode.
+ */
+export const ALLOWED_UPLOAD_TYPES: Readonly<Record<string, readonly string[]>> =
+  {
+    // Images
+    "image/jpeg": [".jpg", ".jpeg"],
+    "image/png": [".png"],
+    "image/webp": [".webp"],
+    "image/avif": [".avif"],
+    "image/gif": [".gif"],
+    "image/heic": [".heic", ".heif"],
+    "image/heif": [".heic", ".heif"],
+    "image/vnd.adobe.photoshop": [".psd"],
+    "application/octet-stream": [".psd"],
+    // Videos
+    "video/mp4": [".mp4"],
+    "video/quicktime": [".mov"],
+    "video/webm": [".webm"],
+  };
+
+/**
+ * Validates an upload's file type: the MIME type must be allowed and the
+ * filename extension must match that MIME type.
+ */
+export function validateUploadFileType(
+  filename: string,
+  mimeType: string,
+): boolean {
+  const allowedExtensions = ALLOWED_UPLOAD_TYPES[mimeType];
+  if (!allowedExtensions) {
+    return false;
+  }
+  return allowedExtensions.includes(path.extname(filename).toLowerCase());
+}

--- a/packages/core/src/utils/video/format.ts
+++ b/packages/core/src/utils/video/format.ts
@@ -1,7 +1,7 @@
 /**
  * Supported image formats for video thumbnails
  */
-export const IMAGE_FORMATS = new Set(["jpg", "jpeg", "png", "webp", "avif", "gif", "psd"]);
+export const IMAGE_FORMATS = new Set(["jpg", "jpeg", "png", "webp", "avif", "gif"]);
 
 /**
  * Supported video formats

--- a/packages/ui/src/components/upload-section.tsx
+++ b/packages/ui/src/components/upload-section.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 import { useDropzone } from "react-dropzone";
+import { DEFAULT_ACCEPT } from "../file-uploader/use-file-upload";
 
 interface UploadResult {
   filename: string;
@@ -61,10 +62,9 @@ export function UploadSection({ uploadToFolder }: { uploadToFolder?: string }) {
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
-    accept: {
-      "image/*": [".jpg", ".jpeg", ".png", ".webp", ".avif", ".gif", ".psd"],
-      "video/*": [".mp4", ".mov", ".webm"],
-    },
+    // Mirrors the API's ALLOWED_TYPES. The previous "image/*" / "video/*"
+    // wildcards let the picker accept files (svg, tiff, mkv…) the API rejects.
+    accept: DEFAULT_ACCEPT,
   });
 
   const handleFolderSelect = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/ui/src/components/upload-section.tsx
+++ b/packages/ui/src/components/upload-section.tsx
@@ -189,7 +189,8 @@ export function UploadSection({ uploadToFolder }: { uploadToFolder?: string }) {
                   Drop files here, or click to select files
                 </p>
                 <p className="text-sm text-muted-foreground">
-                  Supports: JPG, PNG, WebP, AVIF, GIF, PSD, MP4, MOV, WebM
+                  Supports: JPG, PNG, WebP, AVIF, GIF, HEIC, PSD, MP4, MOV,
+                  WebM
                 </p>
                 <div className="flex gap-2 mt-2">
                   <Button


### PR DESCRIPTION
## Contexte

Le paramètre `f_` du parser acceptait `avi`, `mp3`, `wav`, `ogg`, `pdf` et `psd`. Aucun encodeur ne produit ces formats : ils retombaient silencieusement sur PNG ou MP4 pendant que la réponse gardait le `Content-Type` du format demandé.

## Bugs trouvés en tirant le fil

- **`f_gif` sur une image servait des octets PNG sous `Content-Type: image/gif`.** `applyFormat` n'avait pas de case `gif` et tombait sur le `default: png`, mais le content-type venait du format *demandé* (`transform-helpers.ts:272`). sharp encode le GIF, donc case ajoutée — c'est maintenant réellement supporté.
- **`f_mp4` sur un `.jpg` servait du PNG étiqueté `image/mp4`.** Même mécanique. Un format vidéo demandé sur une source image retombe désormais sur la sélection auto : bytes valides, étiquette juste.

## Autres changements

- `psd` reste un format d'**upload** accepté mais n'est plus un format de **sortie** — il générait un `image/psd` bidon via le fallback de `contentTypeForFormat`.
- `UploadSection` utilisait des wildcards `image/*` / `video/*` dans sa dropzone : le sélecteur acceptait svg, tiff, mkv… que l'API refusait ensuite. Il réutilise `DEFAULT_ACCEPT`, ce qui supprime au passage une copie qui avait déjà divergé de la liste de l'API.

## ⚠️ Breaking

Les URLs `f_psd` et `f_avi` ne parsent plus comme transformations : le segment est lu comme un nom de dossier et renvoie 404 au lieu d'un fallback silencieux. À vérifier si ce type d'URL existe en prod.

## Tests

`packages/core/src/utils/format-support.test.ts` — 4 tests couvrant la frontière `f_`. 44/44 sur `@openinary/core`, typecheck clean sur `core` et `ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)