### PR TITLE
fix(video): transcode only when the URL asks for it

### DIFF
--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -222,49 +222,6 @@ export function createUploadRoute(deps: RouteDeps) {
     return fs.existsSync(fullPath);
   }
 
-  /**
-   * Queue thumbnail generation for a video
-   * Uses high priority to ensure thumbnails are generated first
-   */
-  async function queueThumbnailGeneration(
-    filePath: string,
-    storage: ReturnType<typeof createStorageClient>,
-  ): Promise<void> {
-    try {
-      // Define default thumbnail parameters (matching frontend defaults)
-      // t_true (thumbnail), tt_5 (time at 5s), f_webp, w_500, h_500, c_fill, q_80
-      const transformPath = `/t/t_true,tt_5,f_webp,w_500,h_500,c_fill,q_80/${filePath}`;
-      const params = parseParams(transformPath);
-      const cachePath = getCachePath(transformPath);
-
-      // Get source path
-      const sourcePath = storage
-        ? `./temp/${path.basename(filePath)}`
-        : path.join("./public", filePath);
-
-      // Add to queue with HIGH priority for thumbnails
-      const jobId = await videoJobQueue.addJob(
-        filePath,
-        params,
-        cachePath,
-        sourcePath,
-        storage,
-        THUMBNAIL_PRIORITY,
-      );
-
-      logger.info(
-        { filePath, jobId, priority: THUMBNAIL_PRIORITY },
-        "Thumbnail generation queued",
-      );
-    } catch (error) {
-      logger.error(
-        { error: serializeError(error), filePath },
-        "Failed to queue thumbnail generation",
-      );
-      // Don't throw - this is a background operation
-    }
-  }
-
   async function queueVideoTransformations(
     filePath: string,
     transformations: string[],
@@ -559,28 +516,23 @@ export function createUploadRoute(deps: RouteDeps) {
               );
             }
 
-            // Queue thumbnail generation for videos (non-blocking, high priority)
-            if (normalizedContentType.startsWith("video/")) {
-              queueThumbnailGeneration(finalPath, storage).catch((error) => {
-                logger.error(
-                  { error: serializeError(error), finalPath },
-                  "Failed to queue thumbnail generation",
-                );
-              });
-
-              if (prewarmTransformations.length > 0) {
-                const queueResult = await queueVideoTransformations(
-                  finalPath,
-                  prewarmTransformations,
-                  storage,
-                );
-                if (queueResult.queuedTransformationUrls.length > 0) {
-                  uploadResult.queuedTransformationUrls =
-                    queueResult.queuedTransformationUrls;
-                }
-                if (queueResult.queueErrors.length > 0) {
-                  uploadResult.queueErrors = queueResult.queueErrors;
-                }
+            // Video variants, including thumbnails, are only generated when the
+            // upload explicitly asks for them via `transformations`
+            if (
+              normalizedContentType.startsWith("video/") &&
+              prewarmTransformations.length > 0
+            ) {
+              const queueResult = await queueVideoTransformations(
+                finalPath,
+                prewarmTransformations,
+                storage,
+              );
+              if (queueResult.queuedTransformationUrls.length > 0) {
+                uploadResult.queuedTransformationUrls =
+                  queueResult.queuedTransformationUrls;
+              }
+              if (queueResult.queueErrors.length > 0) {
+                uploadResult.queueErrors = queueResult.queueErrors;
               }
             }
 
@@ -627,28 +579,23 @@ export function createUploadRoute(deps: RouteDeps) {
               );
             }
 
-            // Queue thumbnail generation for videos (non-blocking, high priority)
-            if (normalizedContentType.startsWith("video/")) {
-              queueThumbnailGeneration(finalPath, storage).catch((error) => {
-                logger.error(
-                  { error: serializeError(error), finalPath },
-                  "Failed to queue thumbnail generation",
-                );
-              });
-
-              if (prewarmTransformations.length > 0) {
-                const queueResult = await queueVideoTransformations(
-                  finalPath,
-                  prewarmTransformations,
-                  storage,
-                );
-                if (queueResult.queuedTransformationUrls.length > 0) {
-                  uploadResult.queuedTransformationUrls =
-                    queueResult.queuedTransformationUrls;
-                }
-                if (queueResult.queueErrors.length > 0) {
-                  uploadResult.queueErrors = queueResult.queueErrors;
-                }
+            // Video variants, including thumbnails, are only generated when the
+            // upload explicitly asks for them via `transformations`
+            if (
+              normalizedContentType.startsWith("video/") &&
+              prewarmTransformations.length > 0
+            ) {
+              const queueResult = await queueVideoTransformations(
+                finalPath,
+                prewarmTransformations,
+                storage,
+              );
+              if (queueResult.queuedTransformationUrls.length > 0) {
+                uploadResult.queuedTransformationUrls =
+                  queueResult.queuedTransformationUrls;
+              }
+              if (queueResult.queueErrors.length > 0) {
+                uploadResult.queueErrors = queueResult.queueErrors;
               }
             }
 

--- a/docs/api-reference/media/transform.mdx
+++ b/docs/api-reference/media/transform.mdx
@@ -280,6 +280,20 @@ Uniform 16 px radius with white corners, safe to serve as JPEG on a white page.
   variants at upload time so the first request is served from cache.
 </Warning>
 
+<Note>
+  Videos are never transcoded unless the URL asks for it. `GET /t/clip.mp4`
+  streams the untouched original. Use `q_auto` to opt into the default
+  optimization (`GET /t/q_auto/clip.mp4`), or any explicit parameter.
+
+While a video transformation is still being processed, the endpoint answers
+`202 Accepted` instead of the original, so a request never returns content whose
+transformations have not been applied yet. Poll the `statusUrl` from the
+response body — see [video status](/api-reference/video/status) — and retry once
+it reports `completed`. That URL keeps the transformation segment, since the job
+is keyed on the path *and* its parameters.
+
+</Note>
+
 ### Quick reference
 
 | Param             | Full name      | Description                                                     |
@@ -342,8 +356,8 @@ Uniform 16 px radius with white corners, safe to serve as JPEG on a white page.
 </ParamField>
 
 <a id="q-video"></a>
-<ParamField path="q" type="integer" default="75">
-  Video quality via <Tooltip tip="Constant Rate Factor, lower CRF = better quality, larger file">CRF</Tooltip> encoding. Range: 1–100.
+<ParamField path="q" type="integer | auto" default="75">
+  Video quality via <Tooltip tip="Constant Rate Factor, lower CRF = better quality, larger file">CRF</Tooltip> encoding. Range: 1–100, or `auto` to opt a video into the default optimization without picking a CRF yourself.
 
 | `q` value | CRF | Notes                         |
 | --------- | --- | ----------------------------- |
@@ -474,7 +488,17 @@ Returns the binary content of the transformed file.
 | `Content-Type`  | Detected from output format (e.g. `image/webp`, `video/mp4`) |
 | `Cache-Control` | Set for browser caching                                      |
 
-**Status codes:** `200` success · `404` file not found · `500` processing error
+**Status codes:** `200` success · `202` video transformation still processing · `404` file not found · `500` processing error
+
+A `202` carries a JSON body instead of media, and a `Retry-After` header:
+
+```json
+{
+  "status": "processing",
+  "message": "Video transformation is being processed",
+  "statusUrl": "/video-status/w_640,q_80/videos/clip.mp4"
+}
+```
 
 ## Related
 

--- a/docs/media-transformations/upload-and-prewarm.mdx
+++ b/docs/media-transformations/upload-and-prewarm.mdx
@@ -19,8 +19,11 @@ curl -X POST "http://localhost:3000/upload" \
 ```
 
 <Note>
-  Even without a `transformations` field, Openinary automatically queues a
-  default thumbnail for every video upload.
+  An upload never processes a video on its own, not even for a thumbnail. To
+  prewarm one, request it like any other variant:
+  `t_true,tt_5,f_webp,w_500,h_500,c_fill,q_80`. Thumbnails are queued ahead of
+  other video work. Without it, the first request to a thumbnail URL extracts
+  the frame on demand (~1s) and caches it.
 </Note>
 
 ## TypeScript examples

--- a/docs/media-transformations/video-transformations.mdx
+++ b/docs/media-transformations/video-transformations.mdx
@@ -9,6 +9,14 @@ description: "Resize, trim, extract thumbnails, and re-encode videos with URL-ba
   variants at upload time so the first request is served from cache.
 </Warning>
 
+<Note>
+  A video is only transcoded when the URL asks for it. `/t/clip.mp4` streams the
+  original untouched; `/t/q_auto/clip.mp4` opts into the default optimization.
+  Until a requested transformation is ready, the URL answers `202 Accepted`
+  rather than serving the original, so an untransformed (unwatermarked,
+  uncropped) file is never delivered in its place.
+</Note>
+
 All video transformation parameters, the CRF quality table, and examples are documented in the API reference.
 
 <Card

--- a/packages/core/src/routes/authenticated.ts
+++ b/packages/core/src/routes/authenticated.ts
@@ -152,9 +152,14 @@ export function createAuthenticatedRoute(deps: RouteDeps) {
         c.header("Content-Type", result.contentType);
       }
 
-      // Large payloads (e.g. original videos during processing) are streamed
+      // Large payloads (e.g. untransformed originals) are streamed
       if (result.stream) {
         return c.body(result.stream);
+      }
+
+      // Video transform still running: no content to serve yet
+      if (result.status === 202) {
+        return c.body(new Uint8Array(result.buffer!), 202);
       }
 
       // Check if this is an error response

--- a/packages/core/src/routes/transform.ts
+++ b/packages/core/src/routes/transform.ts
@@ -47,9 +47,14 @@ export function createTransformRoute(deps: RouteDeps) {
         c.header("Content-Type", result.contentType);
       }
 
-      // Large payloads (e.g. original videos during processing) are streamed
+      // Large payloads (e.g. untransformed originals) are streamed
       if (result.stream) {
         return c.body(result.stream);
+      }
+
+      // Video transform still running: no content to serve yet
+      if (result.status === 202) {
+        return c.body(new Uint8Array(result.buffer!), 202);
       }
 
       // Check if this is an error response

--- a/packages/core/src/routes/video-status.ts
+++ b/packages/core/src/routes/video-status.ts
@@ -1,8 +1,26 @@
 import { Hono } from "hono";
 import type { RouteDeps } from "../config/deps";
-import { parseParams } from "../utils/parser";
+import { parseParams, isTransformSegment } from "../utils/parser";
 import { getCachePath, existsInCache } from "../utils/cache";
 import logger, { serializeError } from "../utils/logger";
+
+/**
+ * Split a /video-status URL into the same (filePath, params, cachePath) triple
+ * the transform route derives, so a status lookup finds the job that the
+ * matching /t/ URL queued. The transformation segment, when present, belongs to
+ * the params, not to the file path the job is keyed on.
+ */
+function resolveStatusTarget(requestPath: string) {
+  const segments = requestPath.split("/").slice(2); // drop '/video-status'
+  const hasTransform = segments.length > 0 && isTransformSegment(segments[0]);
+  const fullPath = `/t/${segments.join("/")}`;
+
+  return {
+    filePath: (hasTransform ? segments.slice(1) : segments).join("/"),
+    params: parseParams(fullPath),
+    cachePath: getCachePath(fullPath),
+  };
+}
 
 export function createVideoStatusRoute(deps: RouteDeps) {
   const { storage, queue: videoJobQueue } = deps;
@@ -15,14 +33,10 @@ export function createVideoStatusRoute(deps: RouteDeps) {
    */
   videoStatus.get("/*/size", async (c) => {
     const path = c.req.path;
-    // Remove '/video-status' prefix and '/size' suffix
-    const segments = path.split("/").slice(2, -1); // Remove 'video-status' and 'size'
-    const filePath = segments.join("/");
-
-    // Parse params from query string or path
-    // Use the same path format as transform.ts: /t/{filePath}
-    const fullPath = `/t/${filePath}`;
-    const params = parseParams(fullPath);
+    // Remove the '/size' suffix, the rest is parsed like a transform path
+    const { filePath, params, cachePath } = resolveStatusTarget(
+      path.replace(/\/size$/, ""),
+    );
 
     // Get job status first - if job is completed, we know the cache exists
     const job = videoJobQueue.getJobByPath(filePath, params);
@@ -31,7 +45,6 @@ export function createVideoStatusRoute(deps: RouteDeps) {
       {
         requestPath: path,
         filePath,
-        fullPath,
         params: JSON.stringify(params),
         jobStatus: job?.status,
         jobId: job?.id,
@@ -75,9 +88,6 @@ export function createVideoStatusRoute(deps: RouteDeps) {
     }
 
     // Fallback: Check if optimized video exists in local cache
-    // Use the same path format as transform.ts uses for getCachePath
-    const cachePath = getCachePath(fullPath);
-
     const existsLocally = await existsInCache(cachePath);
 
     logger.info(
@@ -165,13 +175,7 @@ export function createVideoStatusRoute(deps: RouteDeps) {
    * Check video processing status
    */
   videoStatus.get("/*", async (c) => {
-    const path = c.req.path;
-    const segments = path.split("/").slice(2); // Remove '/video-status' prefix
-    const filePath = segments.join("/");
-
-    // Parse params from query string or path
-    const fullPath = `/t/${filePath}`;
-    const params = parseParams(fullPath);
+    const { filePath, params, cachePath } = resolveStatusTarget(c.req.path);
 
     // Get job status
     const job = videoJobQueue.getJobByPath(filePath, params);
@@ -181,7 +185,6 @@ export function createVideoStatusRoute(deps: RouteDeps) {
       // BUT: Only return "completed" if the file is recent enough to be valid
       // This prevents false positives for newly uploaded videos
 
-      const cachePath = getCachePath(fullPath);
       const existsLocally = await existsInCache(cachePath);
 
       if (existsLocally) {

--- a/packages/core/src/services/transform.service.test.ts
+++ b/packages/core/src/services/transform.service.test.ts
@@ -1,0 +1,113 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { TransformService } from "./transform.service";
+import { createVideoStatusRoute } from "../routes/video-status";
+
+const fakeStorage = (): any => ({
+  existsOriginal: async () => true,
+  exists: async () => false, // cloud cache always misses
+  downloadOriginalStream: async () => ({
+    stream: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([0, 1, 2]));
+        controller.close();
+      },
+    }),
+    contentLength: 3,
+  }),
+});
+
+const fakeQueue = (job?: unknown): any => ({
+  getJobByPath: () => job,
+  addJob: async () => "job-1",
+  getStore: () => ({ updateJobStatus: () => {} }),
+});
+
+test("a bare video URL serves the original and queues nothing", async () => {
+  const queue = fakeQueue();
+  let queued = false;
+  queue.addJob = async () => {
+    queued = true;
+    return "job-1";
+  };
+  const service = new TransformService(fakeStorage(), queue);
+
+  const result = await service.transform({
+    path: "/t/clip.mp4",
+    userAgent: "",
+    context: {} as any,
+  });
+
+  assert.equal(queued, false);
+  assert.ok(result.stream, "original should be streamed");
+  assert.equal(result.status, undefined);
+  assert.equal(result.contentType, "video/mp4");
+});
+
+test("a pending video transform answers 202 instead of the original", async () => {
+  const service = new TransformService(
+    fakeStorage(),
+    fakeQueue({ id: "j1", status: "processing" }),
+  );
+
+  const result = await service.transform({
+    path: "/t/w_640,q_80/clip.mp4",
+    userAgent: "",
+    context: {} as any,
+  });
+
+  assert.equal(result.status, 202);
+  assert.equal(result.stream, undefined, "must not fall back to the original");
+  assert.equal(JSON.parse(result.buffer!.toString()).status, "processing");
+});
+
+test("the 202 status URL resolves to the job the transform queued", async () => {
+  const lookups: Array<{ filePath: string; params: any }> = [];
+  const queue = fakeQueue({ id: "j1", status: "processing" });
+  queue.getJobByPath = (filePath: string, params: any) => {
+    lookups.push({ filePath, params });
+    return { id: "j1", status: "processing", progress: 42 };
+  };
+
+  const service = new TransformService(fakeStorage(), queue);
+  const { statusUrl } = JSON.parse(
+    (
+      await service.transform({
+        path: "/t/w_640,q_80/videos/clip.mp4",
+        userAgent: "",
+        context: {} as any,
+      })
+    ).buffer!.toString(),
+  );
+
+  const app = new Hono().route(
+    "/video-status",
+    createVideoStatusRoute({ storage: null, queue } as any),
+  );
+  const response = await app.request(statusUrl);
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    status: "processing",
+    progress: 42,
+  });
+  // Same key the transform used: the transformation segment is params, not path
+  assert.deepEqual(lookups.at(-1), {
+    filePath: "videos/clip.mp4",
+    params: { width: "640", quality: "80" },
+  });
+});
+
+test("q_auto opts a video into transformation", async () => {
+  const service = new TransformService(fakeStorage(), fakeQueue());
+
+  const result = await service.transform({
+    path: "/t/q_auto/clip.mp4",
+    userAgent: "",
+    context: {} as any,
+  });
+
+  assert.equal(result.status, 202);
+  assert.equal(result.stream, undefined);
+});

--- a/packages/core/src/services/transform.service.ts
+++ b/packages/core/src/services/transform.service.ts
@@ -17,6 +17,10 @@ import {
   performPeriodicCacheCleanup,
 } from "../routes/transform-helpers";
 import { TRANSFORMATION_PRIORITY } from "../utils/video/config";
+import { VIDEO_FORMATS, contentTypeForFormat } from "../utils/video/format";
+
+const isVideo = (ext: string | undefined): ext is string =>
+  !!ext && VIDEO_FORMATS.has(ext);
 
 // Types for the service
 export interface TransformRequest {
@@ -34,6 +38,8 @@ export interface TransformResult {
   headers: Record<string, string>;
   isProcessing?: boolean;
   optimizationResult?: any;
+  /** Non-200 status the route handler must apply (e.g. 202 while transcoding) */
+  status?: number;
 }
 
 export interface CacheCheckResult {
@@ -92,6 +98,13 @@ export class TransformService {
         throw new Error(fileCheck.error || "File not found");
       }
 
+      // A bare /t/<video> URL delivers the untouched original. Transcoding only
+      // happens when the URL asks for it, either with explicit parameters or
+      // with q_auto for the default optimization.
+      if (isVideo(ext) && Object.keys(effectiveParams).length === 0) {
+        return await this.streamOriginalVideo(filePath, localPath, ext);
+      }
+
       // Check caches
       const cacheResult = await this.checkCaches(
         this.storage,
@@ -120,6 +133,7 @@ export class TransformService {
 
       // Process the file
       return await this.processFile(
+        path,
         filePath,
         localPath,
         ext,
@@ -223,7 +237,7 @@ export class TransformService {
     };
 
     // For videos, add video-specific headers
-    if (ext?.match(/mp4|mov|webm/)) {
+    if (isVideo(ext)) {
       headers["X-Video-Status"] = "ready";
     }
 
@@ -239,6 +253,7 @@ export class TransformService {
    * Process the file (images and videos)
    */
   private async processFile(
+    requestPath: string,
     filePath: string,
     localPath: string,
     ext: string | undefined,
@@ -253,8 +268,9 @@ export class TransformService {
     // response and waste memory/bandwidth.
     const isThumbnailRequest =
       effectiveParams.thumbnail === "true" || effectiveParams.thumbnail === "1";
-    if (ext?.match(/mp4|mov|webm/) && !isThumbnailRequest) {
+    if (isVideo(ext) && !isThumbnailRequest) {
       return await this.handleVideoJobQueue(
+        requestPath,
         filePath,
         localPath,
         effectiveParams,
@@ -286,7 +302,7 @@ export class TransformService {
         buffer = result.buffer;
         contentType = result.contentType;
         optimizationResult = result.optimizationResult;
-      } else if (ext?.match(/mp4|mov|webm/)) {
+      } else if (isVideo(ext)) {
         // Only thumbnail requests reach this point (non-thumbnail video
         // transformations are intercepted before prepareSourceFile above);
         // thumbnails are extracted synchronously like images
@@ -339,7 +355,7 @@ export class TransformService {
       }
 
       // For videos, indicate this is the optimized version
-      if (ext?.match(/mp4|mov|webm/)) {
+      if (isVideo(ext)) {
         headers["X-Video-Status"] = "ready";
       }
 
@@ -383,6 +399,7 @@ export class TransformService {
    * Handle video job queue management
    */
   private async handleVideoJobQueue(
+    requestPath: string,
     filePath: string,
     localPath: string,
     params: any,
@@ -464,50 +481,70 @@ export class TransformService {
         });
     }
 
-    // Stream the original video immediately, without buffering it in memory:
-    // originals can weigh hundreds of MB and buffering both delays the first
-    // byte and pressures the container memory while ffmpeg jobs are running
+    // Never fall back to the original while the transform is pending: it would
+    // ship content whose transformations (watermark, crop, trim) have not been
+    // applied yet. Answer 202 and let the client poll /video-status.
+    return {
+      buffer: Buffer.from(
+        JSON.stringify({
+          status: "processing",
+          message: "Video transformation is being processed",
+          // Keeps the transformation segment: /video-status resolves the job
+          // from the same path + params the transform URL carries
+          statusUrl: requestPath.replace(/^\/t\//, "/video-status/"),
+        }),
+      ),
+      contentType: "application/json",
+      status: 202,
+      headers: {
+        "X-Video-Status": "processing",
+        "Cache-Control": "no-store",
+        "Retry-After": "5",
+      },
+      isProcessing: true,
+    };
+  }
+
+  /**
+   * Stream the untouched original without buffering it in memory: originals can
+   * weigh hundreds of MB and buffering both delays the first byte and pressures
+   * the container memory while ffmpeg jobs are running.
+   */
+  private async streamOriginalVideo(
+    filePath: string,
+    localPath: string,
+    ext: string,
+  ): Promise<TransformResult> {
     // encodeURIComponent keeps ETag ASCII-only: HTTP header values must be a
     // ByteString, and raw file paths can contain non-ASCII or NFD-decomposed
     // accented characters (e.g. a combining accent has a code point > 255)
-    const processingHeaders: Record<string, string> = {
-      "X-Video-Status": "processing",
-      "X-Original-Video": "true",
-      "Cache-Control": "public, max-age=0, must-revalidate",
-      ETag: `"${encodeURIComponent(filePath)}-processing-${Date.now()}"`,
-      Vary: "Accept",
+    const headers: Record<string, string> = {
+      "X-Video-Status": "original",
+      "Cache-Control": "public, max-age=31536000, must-revalidate",
+      ETag: `"${encodeURIComponent(filePath)}-original"`,
     };
 
     try {
-      if (this.storage) {
-        const { stream, contentLength } =
-          await this.storage.downloadOriginalStream(filePath);
-        if (contentLength) {
-          processingHeaders["Content-Length"] = contentLength.toString();
-        }
+      let stream: ReadableStream<Uint8Array>;
 
-        return {
-          stream,
-          contentType: `video/${filePath.split(".").pop()}`,
-          headers: processingHeaders,
-          isProcessing: true,
-        };
+      if (this.storage) {
+        const original = await this.storage.downloadOriginalStream(filePath);
+        if (original.contentLength) {
+          headers["Content-Length"] = original.contentLength.toString();
+        }
+        stream = original.stream;
+      } else {
+        const { createReadStream } = await import("fs");
+        const { stat } = await import("fs/promises");
+        const { Readable } = await import("stream");
+        const stats = await stat(localPath);
+        headers["Content-Length"] = stats.size.toString();
+        stream = Readable.toWeb(
+          createReadStream(localPath),
+        ) as ReadableStream<Uint8Array>;
       }
 
-      const { createReadStream } = await import("fs");
-      const { stat } = await import("fs/promises");
-      const stats = await stat(localPath);
-      processingHeaders["Content-Length"] = stats.size.toString();
-      const { Readable } = await import("stream");
-
-      return {
-        stream: Readable.toWeb(
-          createReadStream(localPath),
-        ) as ReadableStream<Uint8Array>,
-        contentType: `video/${filePath.split(".").pop()}`,
-        headers: processingHeaders,
-        isProcessing: true,
-      };
+      return { stream, contentType: contentTypeForFormat(ext), headers };
     } catch (error) {
       logger.error(
         { error: serializeError(error), filePath },

--- a/packages/ui/src/details-sidebar/asset-details-sidebar.tsx
+++ b/packages/ui/src/details-sidebar/asset-details-sidebar.tsx
@@ -28,15 +28,12 @@ export function AssetDetailsSidebar({
   const {
     asset,
     fileSize,
-    optimizedSize,
     createdAt,
     isDeleting,
     deleteDialogOpen,
     mediaUrl,
     previewUrl,
     transformBaseUrl,
-    videoStatus,
-    videoProgress,
     handleCopyUrl,
     handleDownload,
     handleOpenInNewTab,
@@ -89,12 +86,9 @@ export function AssetDetailsSidebar({
                 <AssetDetailsTab
                   asset={asset}
                   fileSize={fileSize}
-                  optimizedSize={optimizedSize}
                   createdAt={createdAt}
                   mediaUrl={mediaUrl}
                   isDeleting={isDeleting}
-                  videoStatus={videoStatus}
-                  videoProgress={videoProgress}
                   onCopyUrl={handleCopyUrl}
                   onDownload={handleDownload}
                   onOpenInNewTab={handleOpenInNewTab}

--- a/packages/ui/src/details-sidebar/asset-details-tab.tsx
+++ b/packages/ui/src/details-sidebar/asset-details-tab.tsx
@@ -10,27 +10,20 @@ import {
   Check,
   Download,
   Trash2,
-  Zap,
-  CheckCircle2,
-  AlertCircle,
 } from "lucide-react";
 import { CopyInput } from "../ui/copy-input";
 import { Button } from "../ui/button";
 import { cn } from "../lib/utils";
 import type { MediaFile } from "../types";
-import type { VideoStatus } from "../hooks/use-video-status";
 import { formatFileSize, formatDate, getFileType } from "./utils";
 import { Spinner } from "../ui/spinner";
 
 interface AssetDetailsTabProps {
   asset: MediaFile;
   fileSize: number | null;
-  optimizedSize: number | null;
   createdAt: Date | null;
   mediaUrl: string;
   isDeleting: boolean;
-  videoStatus?: VideoStatus;
-  videoProgress?: number;
   onCopyUrl: () => void;
   onDownload: () => void;
   onOpenInNewTab: () => void;
@@ -40,12 +33,9 @@ interface AssetDetailsTabProps {
 export function AssetDetailsTab({
   asset,
   fileSize,
-  optimizedSize,
   createdAt,
   mediaUrl,
   isDeleting,
-  videoStatus,
-  videoProgress = 0,
   onCopyUrl,
   onDownload,
   onOpenInNewTab,
@@ -137,62 +127,15 @@ export function AssetDetailsTab({
           </div>
         </div>
 
-        {asset.type === "video" && (
-          <div className="space-y-2">
-            <label className="text-sm font-medium flex items-center gap-2">
-              <Zap className="h-4 w-4" />
-              Optimization Status
-            </label>
-            <div className="text-sm text-muted-foreground flex items-center gap-2 min-h-[20px] transition-opacity duration-200">
-              {(!videoStatus || videoStatus === "unknown") ? (
-                <span className="opacity-50">Checking status...</span>
-              ) : videoStatus === "processing" ? (
-                <>
-                  <Spinner size={16} className="text-primary" />
-                  <span>
-                    Processing video{videoProgress > 0 ? ` (${Math.round(videoProgress)}%)` : "..."}
-                  </span>
-                </>
-              ) : videoStatus === "ready" ? (
-                <>
-                  <CheckCircle2 className="h-3 w-3 text-green-500" />
-                  <span>Optimized version ready</span>
-                </>
-              ) : videoStatus === "error" ? (
-                <>
-                  <AlertCircle className="h-3 w-3 text-destructive" />
-                  <span>Processing failed</span>
-                </>
-              ) : null}
-            </div>
-          </div>
-        )}
-
         <div className="space-y-2">
           <label className="text-sm font-medium flex items-center gap-2">
             <HardDrive className="h-4 w-4" />
             Asset Size
           </label>
           <div className="text-sm text-muted-foreground">
-            {asset.type === "video"
-              ? optimizedSize
-                ? formatFileSize(optimizedSize)
-                : formatFileSize(fileSize)
-              : formatFileSize(fileSize)}
+            {formatFileSize(fileSize)}
           </div>
         </div>
-
-        {asset.type === "video" && (
-          <div className="space-y-2">
-            <label className="text-sm font-medium flex items-center gap-2">
-              <HardDrive className="h-4 w-4" />
-              Original Size
-            </label>
-            <div className="text-sm text-muted-foreground">
-              {formatFileSize(fileSize)}
-            </div>
-          </div>
-        )}
 
         <div className="space-y-2">
           <label className="text-sm font-medium flex items-center gap-2">

--- a/packages/ui/src/details-sidebar/use-asset-details.ts
+++ b/packages/ui/src/details-sidebar/use-asset-details.ts
@@ -8,7 +8,6 @@ import { useOpeninary } from "../provider/openinary-provider";
 import { getMediaType } from "../media-type";
 import { invalidateStorage } from "../hooks/use-storage-tree";
 import { usePreloadMedia } from "../hooks/use-preload-media";
-import { useVideoStatus } from "../hooks/use-video-status";
 import type { MediaFile } from "../types";
 
 export function useAssetDetails(
@@ -20,7 +19,6 @@ export function useAssetDetails(
   const queryClient = useQueryClient();
   const [asset, setAsset] = useState<MediaFile | null>(null);
   const [fileSize, setFileSize] = useState<number | null>(null);
-  const [optimizedSize, setOptimizedSize] = useState<number | null>(null);
   const [createdAt, setCreatedAt] = useState<Date | null>(null);
   const [updatedAt, setUpdatedAt] = useState<Date | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -63,63 +61,6 @@ export function useAssetDetails(
     }
   };
 
-  const fetchOptimizedSize = async (path: string) => {
-    try {
-      // Encode each segment separately to preserve slashes
-      const encodedPath = path
-        .split("/")
-        .map((segment) => encodeURIComponent(segment))
-        .join("/");
-
-      const url = `${apiBaseUrl}/video-status/${encodedPath}/size`;
-
-      const response = await fetch(url, { method: "GET" });
-
-      if (response.ok) {
-        const data = await response.json();
-        if (data.size && data.status === "ready") {
-          setOptimizedSize(data.size);
-          return;
-        }
-      } else {
-        const errorText = await response.text();
-        console.warn("Failed to get optimized size:", response.status, errorText);
-      }
-
-      // Fallback: Try HEAD request on transform endpoint
-      const headResponse = await fetch(`${transformBaseUrl}/t/${path}`, {
-        method: "HEAD",
-      });
-
-      if (headResponse.ok) {
-        const videoStatus = headResponse.headers.get("X-Video-Status");
-        const isOriginal = headResponse.headers.get("X-Original-Video") === "true";
-        const optimizedSizeHeader = headResponse.headers.get("X-Optimized-Size");
-        const contentLength = headResponse.headers.get("Content-Length");
-
-        // If X-Optimized-Size header is present, use it directly
-        if (optimizedSizeHeader) {
-          setOptimizedSize(parseInt(optimizedSizeHeader, 10));
-          return;
-        }
-
-        // Only use Content-Length if it's the optimized version (not the original)
-        if (videoStatus === "ready" && !isOriginal && contentLength) {
-          const size = parseInt(contentLength, 10);
-          if (size > 0) {
-            setOptimizedSize(size);
-            return;
-          }
-        }
-      }
-
-      setOptimizedSize(null);
-    } catch (error) {
-      console.error("Failed to fetch optimized size:", error);
-      setOptimizedSize(null);
-    }
-  };
-
   // Resolve the asset directly from its id (the id IS the storage path);
   // existence is confirmed by the metadata fetch below (404 clears it)
   useEffect(() => {
@@ -144,14 +85,8 @@ export function useAssetDetails(
   useEffect(() => {
     if (asset) {
       fetchFileMetadata(asset.path);
-      if (asset.type === "video") {
-        fetchOptimizedSize(asset.path);
-      } else {
-        setOptimizedSize(null);
-      }
     } else {
       setFileSize(null);
-      setOptimizedSize(null);
       setCreatedAt(null);
       setUpdatedAt(null);
     }
@@ -171,33 +106,6 @@ export function useAssetDetails(
   // Preload preview media when asset changes
   // Note: Even videos are preloaded as "image" since we extract thumbnails
   usePreloadMedia(previewUrl, "image");
-
-  // Track video processing status
-  const videoPath = asset?.type === "video" ? asset.path : null;
-  const { status: videoStatus, progress: videoProgress } = useVideoStatus(videoPath, !!asset);
-
-  // Retry fetching optimized size when video status becomes ready
-  useEffect(() => {
-    if (asset?.type === "video" && videoStatus === "ready" && !optimizedSize) {
-      fetchOptimizedSize(asset.path);
-    }
-  }, [asset, videoStatus, optimizedSize]);
-
-  // Trigger job creation for videos when details are opened
-  // This ensures the job is created even if the video hasn't been accessed yet
-  // Do this immediately to ensure the job exists when status is checked
-  useEffect(() => {
-    if (asset?.type === "video" && asset.path && transformBaseUrl) {
-      // Make a HEAD request to the video URL to trigger job creation immediately
-      // This is a lightweight way to ensure the job is created
-      fetch(`${transformBaseUrl}/t/${asset.path}`, {
-        method: "HEAD",
-      }).catch((error) => {
-        // Silently fail - this is just to trigger job creation
-        console.debug("Failed to trigger video job creation:", error);
-      });
-    }
-  }, [asset?.type, asset?.path, transformBaseUrl]);
 
   const handleCopyUrl = () => {
     if (mediaUrl) {
@@ -319,7 +227,6 @@ export function useAssetDetails(
   return {
     asset,
     fileSize,
-    optimizedSize,
     createdAt,
     updatedAt,
     isDeleting,
@@ -328,8 +235,6 @@ export function useAssetDetails(
     previewUrl,
     apiBaseUrl,
     transformBaseUrl,
-    videoStatus,
-    videoProgress,
     handleCopyUrl,
     handleDownload,
     handleOpenInNewTab,

--- a/packages/ui/src/media-grid.tsx
+++ b/packages/ui/src/media-grid.tsx
@@ -478,13 +478,15 @@ export function MediaGrid({
     setFolderPath(folderPath);
   };
 
-  // Preload preview when hovering over a media item
+  // Preload preview when hovering over a media item. Videos preload their
+  // thumbnail (what the grid renders), not the original: /t/<video> now streams
+  // the untouched file, which would pull hundreds of MB on a hover.
   const handleMediaHover = (media: MediaFile) => {
     const previewUrl =
       media.type === "image"
         ? `${transformBaseUrl}/t/w_500,h_500,q_80/${media.path}`
-        : `${transformBaseUrl}/t/${media.path}`;
-    preloadMedia(previewUrl, media.type);
+        : `${transformBaseUrl}/t/t_true,tt_5,f_webp,w_500,h_500,c_fill,q_80/${media.path}`;
+    preloadMedia(previewUrl, "image");
   };
 
   const handleDownload = (path: string, name: string) => {


### PR DESCRIPTION
Closes #93

## Contexte

Deux comportements liés, tous les deux hérités du même postulat : « une vidéo doit être optimisée, donc autant s'y mettre tout de suite ».

1. Une vidéo était transcodée dès qu'on touchait son URL publique (et le dashboard déclenchait ça lui-même avec un HEAD à l'ouverture des détails). Aucune manière de dire non.
2. Pendant que le job tournait, l'URL transformée servait **l'original** en 200. C'est le point soulevé dans #93 : un `w_400` en attente livrait une vidéo non recadrée, un watermark en attente livrait une vidéo sans watermark, sous l'URL censée garantir le contraire.

## Ce qui change

**L'original est servi tel quel.** `GET /t/clip.mp4` stream le fichier intact (octets identiques vérifiés) et ne met plus rien en file. Le transcodage devient opt-in via `q_auto` — comme chez les concurrents — ou n'importe quel paramètre explicite.

**Une transformation en attente répond 202.** Plus de repli sur l'original : `202 Accepted` + `Retry-After: 5` + un JSON `{status, message, statusUrl}`, avec `Cache-Control: no-store`. L'ancien repli avait deux défauts en plus du fond : un ETag basé sur `Date.now()` combiné à `must-revalidate`, donc chaque replay re-téléchargeait la source entière.

**L'upload ne traite plus rien**, vignette comprise. Le champ `transformations` existant couvre déjà le besoin et route déjà les demandes de vignette vers `THUMBNAIL_PRIORITY` :

```bash
-F 'transformations=["t_true,tt_5,f_webp,w_500,h_500,c_fill,q_80"]'
```

Rien ne régresse sans : les vignettes sont extraites de façon synchrone par la route transform, jamais par la file. Premier hit ~1s, puis cache.

## Bug trouvé en tirant le fil

`/video-status` traitait le segment de transformation comme une partie du chemin fichier : `/video-status/w_640,q_80/clip.mp4` cherchait un job pour le fichier `w_640,q_80/clip.mp4` et ne trouvait jamais rien. Invisible jusqu'ici (le dashboard ne pollait que la variante sans paramètre), mais bloquant pour le `statusUrl` que le 202 annonce. La route découpe maintenant son chemin comme la route transform.

## Dashboard

Le panneau *Optimization Status* disparaît, ainsi que le HEAD qui était le déclencheur de fait du transcodage — sans lui le panneau serait resté sur « Checking status… » indéfiniment. Partent avec : le fetch de taille optimisée et le bloc *Original Size*, devenu un doublon exact d'*Asset Size*.

Le hover du grid préchargeait `/t/<video>`, ce qui tirait maintenant l'original entier. Il précharge la vignette webp que le grid affiche déjà.

## ⚠️ Breaking

- Une URL vidéo sans paramètre renvoie l'original, plus la version optimisée. Les variants auto-optimisés déjà en cache (params vides) deviennent orphelins et ne sont plus servis.
- Les clients qui consomment une URL de transformation vidéo doivent gérer le 202 (poll `statusUrl`, retry) au lieu de recevoir un 200.
- Les vignettes ne sont plus pré-générées à l'upload. Les intégrations qui comptaient dessus doivent lister la transformation, ou accepter ~1s sur le premier affichage.

## Tests

`packages/core/src/services/transform.service.test.ts` — 4 tests : original sans job, 202 sans repli, `q_auto` opt-in, et le `statusUrl` du 202 qui résout bien le job que la transformation a mis en file. 48/48 sur `@openinary/core`, typecheck clean partout sauf `apps/web`, déjà cassé avant cette branche (imports `@/components/nav-*` manquants).

Boucle vérifiée bout en bout sur l'API locale : `/t/clip.mp4` → 200 original · `/t/w_640,q_80/clip.mp4` → 202 · `statusUrl` → `completed` · nouvelle requête → 200 vidéo transformée. Vignettes fraîches, 404 et images inchangés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
