### PR TITLE
feat(ui): fade scrollable edges only when they actually scroll

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -45,6 +45,68 @@
   --radius-xl: calc(var(--radius) + 4px);
 }
 
+/* Fades the top and bottom edges of a scrollable area as it scrolls. Lives
+   here rather than in @openinary/ui because that package ships JS only, so
+   every consumer declares the utilities its class names rely on. */
+@property --scroll-fade-t {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+
+@property --scroll-fade-b {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+
+@keyframes scroll-fade-t {
+  from {
+    --scroll-fade-t: 0px;
+  }
+  to {
+    --scroll-fade-t: var(--scroll-fade-size);
+  }
+}
+
+@keyframes scroll-fade-b {
+  from {
+    --scroll-fade-b: var(--scroll-fade-size);
+  }
+  to {
+    --scroll-fade-b: 0px;
+  }
+}
+
+@utility scroll-fade {
+  --scroll-fade-size: 2rem;
+  mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    #000 var(--scroll-fade-t),
+    #000 calc(100% - var(--scroll-fade-b)),
+    transparent
+  );
+
+  /* Both sizes stay 0 while the timeline is inactive, which is what makes
+     content that doesn't overflow come out unfaded. */
+  @supports (animation-timeline: scroll(self block)) {
+    animation:
+      scroll-fade-t linear both,
+      scroll-fade-b linear both;
+    animation-timeline: scroll(self block);
+    animation-range:
+      0 var(--scroll-fade-size),
+      calc(100% - var(--scroll-fade-size)) 100%;
+  }
+
+  /* No timelines: the animations would settle on their end state (a permanent
+     top fade, no bottom one), so drop them and keep a static bottom fade. */
+  @supports not (animation-timeline: scroll(self block)) {
+    --scroll-fade-b: var(--scroll-fade-size);
+  }
+}
+
 :root {
   --radius: 0.625rem;
   --background: oklch(1 0 0);

--- a/packages/ui/src/components/upload-section.tsx
+++ b/packages/ui/src/components/upload-section.tsx
@@ -238,8 +238,8 @@ export function UploadSection({ uploadToFolder }: { uploadToFolder?: string }) {
               </Button>
             </div>
 
-            <div className="relative rounded-lg border overflow-hidden">
-              <div className="divide-y max-h-64 overflow-y-auto">
+            <div className="rounded-lg border overflow-hidden">
+              <div className="scroll-fade divide-y max-h-64 overflow-y-auto">
                 {selectedFiles.slice(0, 50).map((file, index) => {
                   const displayPath =
                     (file as any).webkitRelativePath || file.name;
@@ -266,8 +266,6 @@ export function UploadSection({ uploadToFolder }: { uploadToFolder?: string }) {
                   </div>
                 )}
               </div>
-              <div className="pointer-events-none absolute inset-x-0 top-0 h-6 bg-gradient-to-b from-card to-transparent" />
-              <div className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-card to-transparent" />
             </div>
           </div>
         )}

--- a/packages/ui/src/settings/settings-dialog.tsx
+++ b/packages/ui/src/settings/settings-dialog.tsx
@@ -58,7 +58,7 @@ export function SettingsDialog({
             </button>
           ))}
         </div>
-        <ScrollArea className="flex-1">
+        <ScrollArea className="min-w-0 flex-1 [&>[data-radix-scroll-area-viewport]]:scroll-fade [&>[data-radix-scroll-area-viewport]>div]:block!">
           <div className="px-8 py-6">
             <h2 className="mb-6 text-2xl font-semibold tracking-tight">
               {activeItem?.label}


### PR DESCRIPTION
## What

The upload file list drew two absolutely-positioned gradient overlays permanently. A list of two files — nothing to scroll — still got a fade over solid content, and the hardcoded `from-card` only lined up when the surface underneath happened to be `card`.

Replaced with a `scroll-fade` utility: a `mask-image` driven by `animation-timeline: scroll(self block)`. While the element doesn't overflow the timeline stays inactive, both fade sizes hold at `0px`, and nothing is masked. It also follows whatever background sits underneath, since it masks rather than paints.

Applied to the settings `ScrollArea` too. That change carries two fixes unrelated to the fade: `min-w-0`, and forcing the Radix scroll-area viewport's child to `block` — Radix wraps it in a `display: table` div that grows instead of constraining, so wide content pushed the panel out.

## Where the CSS lives

In `apps/web/src/app/globals.css`, not in the package. `@openinary/ui` ships `dist/*.js` only and no stylesheet, so consumers already own every utility the package's class names reference. Following that split rather than adding a CSS entry point to the package.

Consequence worth naming: a second consumer of `@openinary/ui` has to declare the same utility or the two components lose their fade silently. That is already true of the rest of the package's styling.

## Fallback

Safari < 26 and Firefox have no scroll-driven animations. A `@supports not` branch drops the animations — they would otherwise settle on their end state, which is a permanent top fade and no bottom one — and keeps a static bottom fade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)