### PR TITLE
docs: add Openinary Cloud (early access) documentation

### DIFF
--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -3,6 +3,12 @@ title: "API Reference"
 description: "Complete reference for the Openinary REST API"
 ---
 
+<Note>
+  This reference documents a **self-hosted** instance. Openinary Cloud has its
+  own base URL, authentication and endpoint set, see the [Cloud API
+  Reference](/cloud/api).
+</Note>
+
 ## Base URL
 
 All endpoints are relative to your Openinary server URL.

--- a/docs/cloud/api.mdx
+++ b/docs/cloud/api.mdx
@@ -1,0 +1,347 @@
+---
+title: "Cloud API Reference"
+description: "Base URL, authentication, endpoints, errors and rate limits for the Openinary Cloud API."
+---
+
+## Base URL
+
+Everything, the API and the CDN, is served from one host:
+
+```
+https://cdn.openinary.dev
+```
+
+The dashboard lives at `https://app.openinary.dev`, and is not an API.
+
+## Authentication
+
+Send your API key on every request, either header works:
+
+```http
+x-api-key: oik_your_api_key
+```
+
+```http
+Authorization: Bearer oik_your_api_key
+```
+
+Keys are created in the dashboard (**Settings → API keys**), shown once, and
+**pinned to a single bucket**. Every request a key makes reads and writes that
+bucket, so you never pass a bucket ID to these endpoints, it's carried by the
+key. See [Create an API key](/cloud/quickstart#2-create-an-api-key).
+
+<Warning>
+  API keys are server-side credentials. The only endpoint meant to be called from
+  a browser is `POST /upload`, and only with a
+  [presigned signature](/cloud/file-uploader), never with a key. Every other
+  endpoint's CORS policy is pinned to the dashboard origin, so a browser on your
+  own domain can't call them even if you tried, call them from your backend.
+</Warning>
+
+## Endpoints
+
+| Group      | Endpoint                            | Auth                    |
+| ---------- | ----------------------------------- | ----------------------- |
+| **Media**  | `GET /b/{bucketId}/t/{path}`        | Public                  |
+| **Files**  | `POST /upload`                      | API key **or** presigned |
+|            | `POST /upload/sign`                 | API key                 |
+|            | `POST /upload/createfolder`         | API key                 |
+|            | `GET /download/{path}`              | API key                 |
+| **Storage**| `GET /storage?path=`                | API key                 |
+|            | `GET /storage/folders`              | API key                 |
+|            | `GET /storage/{path}/metadata`      | API key                 |
+|            | `PATCH /storage/{path}`             | API key                 |
+|            | `POST /storage/{path}/move`         | API key                 |
+|            | `POST /storage/{path}/copy`         | API key                 |
+|            | `DELETE /storage/{path}`            | API key                 |
+|            | `GET /storage/stats`                | API key                 |
+|            | `POST /storage/stats/recalculate`   | API key                 |
+|            | `POST /storage/cache/clear`         | API key                 |
+| **Video**  | `GET /video-status/{path}`          | API key                 |
+|            | `GET /queue/events`                 | API key                 |
+
+## Delivery
+
+```
+GET /b/{bucketId}/t/{transformations}/{path}
+```
+
+Public, cached at the edge, no authentication. Omit the transformation segment to
+serve the file as stored.
+
+<ParamField path="bucketId" type="string" required>
+  Your bucket's ID. It's the `/b/…/` segment of the `url` returned by
+  `POST /upload`, and visible on any asset in the dashboard.
+</ParamField>
+
+<ParamField path="transformations" type="string">
+  Comma-separated parameters, e.g. `w_400,h_400,c_fill,f_webp`. Identical syntax
+  to self-hosted, see [Image
+  transformations](/media-transformations/image-transformations) and [Video
+  transformations](/media-transformations/video-transformations).
+</ParamField>
+
+<ParamField path="path" type="string" required>
+  Storage path of the file, e.g. `products/photo.jpg`.
+</ParamField>
+
+The first request for a given URL runs the transformation and caches the result;
+later requests are served from cache. Cached deliveries count as **CDN requests**
+only. An image request that misses the cache also counts as one **image
+transformation**. Video transformations are queued, see [Video
+processing](#video-processing).
+
+## Upload
+
+```
+POST /upload
+```
+
+`multipart/form-data`.
+
+<ParamField path="files" type="file" required>
+  The file to upload. Repeat the field to send several in one request.
+</ParamField>
+
+<ParamField path="folder" type="string">
+  Destination folder, e.g. `products/2026`. Defaults to the bucket root. Ignored
+  when a `signature` is present, the signature carries its own folder.
+</ParamField>
+
+<ParamField path="signature" type="string">
+  A presigned token from `POST /upload/sign`. Use this instead of an API key for
+  browser uploads.
+</ParamField>
+
+```json Response
+{
+  "success": true,
+  "files": [
+    {
+      "path": "products/photo.jpg",
+      "name": "photo.jpg",
+      "filename": "photo.jpg",
+      "size": 248713,
+      "url": "/b/{bucketId}/t/products/photo.jpg"
+    }
+  ]
+}
+```
+
+Accepted types: JPEG, PNG, WebP, AVIF, GIF, HEIC/HEIF, PSD, MP4, MOV, WebM. SVG
+is rejected. HEIC/HEIF is converted to JPEG on upload, so the returned `path` may
+end in `.jpg`. A name that already exists is de-duplicated (`photo (1).jpg`),
+always trust the returned `path` over the one you sent.
+
+<Note>
+  The self-hosted `transformations` field (prewarming variants at upload time) is
+  **not supported on Cloud**. It's ignored, and variants are generated on the
+  first request instead.
+</Note>
+
+## Presigned uploads
+
+```
+POST /upload/sign
+```
+
+Mints a short-lived token so a browser can upload without an API key. Call it
+from your backend only.
+
+<ParamField path="folder" type="string">
+  Folder the upload is scoped to. Derive it from the authenticated user, never
+  from the browser.
+</ParamField>
+
+<ParamField path="expiresIn" type="number" default="300">
+  Lifetime in seconds, clamped to 1–3600. Keep it short, 60–300 is plenty.
+</ParamField>
+
+```json Response
+{
+  "success": true,
+  "signature": "eyJ1IjoiLi4uIn0.9f2c1d4e8a7b6c50",
+  "expires": 1785312000,
+  "folder": "users/42"
+}
+```
+
+The token names the account, bucket, and folder it was minted for, so it can't be
+replayed against another bucket or folder. See [File
+Uploader](/cloud/file-uploader) for the full flow.
+
+## Storage
+
+<AccordionGroup>
+  <Accordion title="GET /storage?path= — list one folder level">
+    ```bash
+    curl "https://cdn.openinary.dev/storage?path=products" \
+      -H "x-api-key: $OPENINARY_API_KEY"
+    ```
+
+    ```json
+    {
+      "path": "products",
+      "folders": [{ "name": "2026", "path": "products/2026" }],
+      "files": [
+        {
+          "name": "photo.jpg",
+          "path": "products/photo.jpg",
+          "size": 248713,
+          "mtime": "2026-07-20T09:12:44.000Z"
+        }
+      ]
+    }
+    ```
+
+  </Accordion>
+  <Accordion title="GET /storage/folders — every folder path in the bucket">
+    ```json
+    { "folders": ["products", "products/2026", "clips"] }
+    ```
+  </Accordion>
+  <Accordion title="GET /storage/{path}/metadata — size and timestamps">
+    ```json
+    {
+      "size": 248713,
+      "createdAt": "2026-07-20T09:12:44.000Z",
+      "updatedAt": "2026-07-20T09:12:44.000Z"
+    }
+    ```
+  </Accordion>
+  <Accordion title="PATCH /storage/{path} — rename in place">
+    Body: `{ "name": "new-name.jpg" }`, a bare name, no slashes. Works on files
+    and folders. Returns `{ "success": true, "path": "products/new-name.jpg" }`.
+  </Accordion>
+  <Accordion title="POST /storage/{path}/move — move to another folder">
+    Body: `{ "destination": "archive/2025" }`. An empty or missing body moves the
+    item to the bucket root. Works on files and folders.
+  </Accordion>
+  <Accordion title="POST /storage/{path}/copy — duplicate a file">
+    No body. The copy is named `photo copy.jpg`, de-duplicated if that already
+    exists. Files only.
+  </Accordion>
+  <Accordion title="DELETE /storage/{path} — delete a file or folder">
+    Deletes the original **and** its cached transform variants. Deleting a folder
+    deletes everything under it. Storage usage is credited back.
+
+    ```json
+    { "success": true, "message": "Asset deleted successfully", "details": { … } }
+    ```
+
+  </Accordion>
+  <Accordion title="GET /storage/stats — bucket footprint">
+    ```json
+    {
+      "storage": { "size": 51288331, "fileCount": 214 },
+      "cache": { "size": 20114882, "fileCount": 619 },
+      "updatedAt": "2026-07-26T18:02:11.000Z"
+    }
+    ```
+
+    Cached figures. `POST /storage/stats/recalculate` recomputes them from
+    storage; `POST /storage/cache/clear` empties the bucket's transform cache
+    (`204`), after which variants are regenerated on demand.
+
+  </Accordion>
+  <Accordion title="GET /download/{path} — fetch the stored original">
+    Authenticated download of the untransformed file, with `Range` support.
+    Public delivery goes through `/b/{bucketId}/t/…` instead.
+  </Accordion>
+</AccordionGroup>
+
+<Note>
+  Paths are URL-encoded in the request and compared as stored, so
+  `products/Marée.jpg` becomes `/storage/products/Mar%C3%A9e.jpg`.
+</Note>
+
+## Video processing
+
+A video transformation is queued rather than run inline. The first request for a
+transformed video returns `202` with a JSON body while it encodes.
+
+```
+GET /video-status/{transformations}/{path}
+```
+
+The transformation segment matters: jobs are tracked per parameter set, so ask
+about the exact URL you requested.
+
+```bash
+curl "https://cdn.openinary.dev/video-status/w_640/clips/demo.mp4" \
+  -H "x-api-key: $OPENINARY_API_KEY"
+```
+
+```json
+{ "status": "running", "progress": 62, "startedAt": "2026-07-26T18:02:11.000Z" }
+```
+
+<ResponseField name="status" type="string">
+  One of `pending` · `running` · `completed` · `error` · `not_found`.
+</ResponseField>
+
+<ResponseField name="progress" type="number">
+  0 to 100.
+</ResponseField>
+
+`GET /queue/events` is a Server-Sent Events stream of the same job updates, for
+when polling is the wrong shape.
+
+<Note>
+  A video URL carrying no parameters is never transcoded, it streams the stored
+  file (with range requests, so seeking works) and costs no processing minutes.
+</Note>
+
+## Errors
+
+```json
+{ "error": "Human-readable message", "message": "Optional detail" }
+```
+
+| Status | Meaning                                                                    |
+| ------ | -------------------------------------------------------------------------- |
+| `400`  | Invalid parameters, unsupported file type, or a malformed path             |
+| `401`  | Missing, invalid, disabled or expired API key, or an expired upload signature |
+| `402`  | A plan limit was reached, see below                                        |
+| `403`  | Account suspended                                                          |
+| `404`  | No such file, folder, bucket, or job                                       |
+| `429`  | Rate limited                                                               |
+| `500`  | Something broke on our side                                                |
+
+A `402` tells you which allowance ran out:
+
+```json
+{
+  "error": "Storage limit reached on the Free plan. Upgrade to lift this limit.",
+  "code": "quota_exceeded",
+  "feature": "storage_mb",
+  "plan": "Free",
+  "planUrl": "https://app.openinary.dev/?settings=plan"
+}
+```
+
+`feature` is one of `storage_mb` · `image_transformations` ·
+`video_processing_seconds` · `cdn_requests`. Over the transformation quota,
+already-cached assets keep being served, only new work is refused. See [Plans and
+limits](/cloud/overview#plans-and-limits).
+
+## Rate limits
+
+| Scope                | Limit                   |
+| -------------------- | ----------------------- |
+| CDN delivery, per IP | 300 requests / 60s      |
+| All traffic, per account | 1,000 requests / 60s |
+
+Both answer `429`. They exist to stop abuse, not to shape normal traffic, if you
+expect to run against them, get in touch before you do.
+
+## Not available on Cloud
+
+These self-hosted endpoints have no Cloud equivalent today:
+
+- `/authenticated/s--{sig}/…` signed delivery URLs
+- `/api-keys/*`, keys are managed in the dashboard
+- `/queue/stats`, `/queue/worker/stats`, `/queue/jobs`, job retry/cancel
+- `/invalidate/{path}`, use `POST /storage/cache/clear`, or delete the asset
+- `/download-folder`, `/download-zip`
+- `/health`

--- a/docs/cloud/file-uploader.mdx
+++ b/docs/cloud/file-uploader.mdx
@@ -1,0 +1,285 @@
+---
+title: "File Uploader on Cloud"
+description: "Wire the Openinary React file uploader to Openinary Cloud: drag & drop uploads straight from the browser, with no API key in the bundle."
+---
+
+The [Openinary File Uploader](/guides/file-uploader) is a shadcn/ui-compatible
+React component with drag & drop, per-file progress, previews, retry, cancel and
+client-side validation. It works against Cloud unchanged, only the configuration
+differs.
+
+This page covers the Cloud wiring. For the full props table, styling and the
+component's own troubleshooting, see the [component
+guide](/guides/file-uploader).
+
+## How it stays safe
+
+The browser never holds your API key. Your backend mints a **short-lived
+presigned signature**, the browser uploads with that.
+
+<Steps>
+  <Step title="Your backend requests a signature">
+    A route you control calls [`POST /upload/sign`](/cloud/api#presigned-uploads)
+    with your Cloud API key, scoping the upload to a folder and an expiry.
+  </Step>
+  <Step title="The browser gets the signature">
+    The component calls your `sign()` function right before uploading and gets
+    back `{ signature, expires, folder }`, opaque values that die in minutes.
+  </Step>
+  <Step title="Cloud verifies it">
+    `POST /upload` reads the destination account, bucket and folder **from the
+    token itself**, never from the request. A tampered, replayed or expired token
+    is rejected.
+  </Step>
+</Steps>
+
+<Note>
+  Because the token names its own bucket, an upload can't be redirected into
+  another bucket, or another customer's storage, by editing the form fields.
+</Note>
+
+## Prerequisites
+
+- A Cloud account, see [Cloud Quickstart](/cloud/quickstart).
+- An **API key** pinned to the bucket you want uploads to land in.
+- A project set up for shadcn/ui (`components.json` present), with the shadcn
+  CLI **v3+** for namespaced registries.
+
+Nothing else. No `API_SECRET`, no `CORS_ORIGIN` allow-list, no
+`MAX_FILE_SIZE_MB`, Cloud handles all of it, and `POST /upload` accepts
+token-authenticated uploads from any origin.
+
+## Installation
+
+<Steps>
+  <Step title="Register the Openinary namespace">
+    ```json components.json
+    {
+      "registries": {
+        "@openinary": "https://raw.githubusercontent.com/openinary/openinary/main/r/{name}.json"
+      }
+    }
+    ```
+  </Step>
+  <Step title="Add the component and the signing helper">
+    ```bash
+    pnpm dlx shadcn@latest add @openinary/file-uploader
+    ```
+
+    ```bash
+    pnpm dlx shadcn@latest add @openinary/upload-token
+    ```
+
+    The first installs the component and its hook into `components/openinary/`;
+    the second installs `lib/upload-token.ts`, a thin client for
+    `POST /upload/sign`.
+
+  </Step>
+  <Step title="Set your environment variables">
+    ```bash .env.local
+    # Public: the browser posts the upload here directly
+    NEXT_PUBLIC_OPENINARY_URL=https://cdn.openinary.dev
+
+    # Secret: server only, never exposed to the browser
+    OPENINARY_API_KEY=oik_your_api_key
+    ```
+
+    <Warning>
+      Unlike a self-hosted full-stack instance, there is **no `/api` suffix** on
+      Cloud. The API is served at the root of `cdn.openinary.dev`.
+    </Warning>
+
+  </Step>
+</Steps>
+
+## Create a signing endpoint
+
+<Warning>
+  Protect this route with your own authentication, and derive `folder` from the
+  **authenticated user** server-side. A folder sent by the browser is a folder
+  any visitor can choose, including someone else's.
+</Warning>
+
+<Tabs>
+  <Tab title="Next.js (App Router)">
+    ```ts app/api/upload-token/route.ts
+    import { NextResponse } from "next/server";
+    import { signUpload } from "@/lib/upload-token";
+    // import { auth } from "@/lib/auth"; // your own auth
+
+    export async function POST() {
+      // const session = await auth();
+      // if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+      const signed = await signUpload(
+        process.env.NEXT_PUBLIC_OPENINARY_URL!,
+        process.env.OPENINARY_API_KEY!,
+        {
+          expiresIn: 300,
+          folder: "uploads", // e.g. `users/${session.user.id}`
+        },
+      );
+
+      return NextResponse.json(signed);
+    }
+    ```
+
+  </Tab>
+  <Tab title="Express">
+    ```ts
+    import express from "express";
+    import { signUpload } from "./lib/upload-token";
+
+    const app = express();
+
+    app.post("/api/upload-token", requireAuth, async (req, res) => {
+      const signed = await signUpload(
+        "https://cdn.openinary.dev",
+        process.env.OPENINARY_API_KEY!,
+        { expiresIn: 300, folder: `users/${req.user.id}` },
+      );
+      res.json(signed);
+    });
+    ```
+
+  </Tab>
+  <Tab title="Cloudflare Workers">
+    ```ts
+    import { signUpload } from "./lib/upload-token";
+
+    export default {
+      async fetch(request: Request, env: Env) {
+        // authenticate the request first...
+        const signed = await signUpload(
+          "https://cdn.openinary.dev",
+          env.OPENINARY_API_KEY,
+          { expiresIn: 300, folder: "uploads" },
+        );
+        return Response.json(signed);
+      },
+    };
+    ```
+
+  </Tab>
+</Tabs>
+
+## Usage
+
+```tsx
+"use client";
+
+import { FileUploader } from "@/components/openinary/file-uploader";
+
+export function Uploader() {
+  const sign = async () => {
+    const res = await fetch("/api/upload-token", { method: "POST" });
+    if (!res.ok) throw new Error("Failed to sign the upload");
+    return res.json();
+  };
+
+  return (
+    <FileUploader
+      sign={sign}
+      maxFiles={10}
+      onSuccess={(files) => {
+        // files[0].url is "/b/{bucketId}/t/{path}"
+        const url = `${process.env.NEXT_PUBLIC_OPENINARY_URL}${files[0].url}`;
+        console.log("Uploaded:", url);
+      }}
+      onError={({ message }) => toast.error(message)}
+    />
+  );
+}
+```
+
+## What comes back
+
+`onSuccess` receives the stored files:
+
+<ResponseField name="path" type="string">
+  The stored path, e.g. `uploads/photo.jpg`. May be de-duplicated if a file of
+  that name already existed (`photo (1).jpg`), so always use this value rather
+  than the name you sent.
+</ResponseField>
+
+<ResponseField name="url" type="string">
+  The delivery path, `/b/{bucketId}/t/{path}`. Prefix it with
+  `https://cdn.openinary.dev` for a full URL, and insert transformations right
+  after `/t/`:
+
+```
+https://cdn.openinary.dev/b/{bucketId}/t/w_600,c_fill,f_webp/uploads/photo.jpg
+```
+
+</ResponseField>
+
+<ResponseField name="filename" type="string">
+  The stored filename.
+</ResponseField>
+
+<Note>
+  HEIC/HEIF files are converted to JPEG on upload, so `path` may end in `.jpg`.
+</Note>
+
+## Cloud-specific behaviour
+
+| Prop / field                                  | On Cloud                                                                                         |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `baseUrl` / `NEXT_PUBLIC_OPENINARY_URL`        | `https://cdn.openinary.dev`, no `/api` suffix                                                     |
+| `transformations`                              | **Ignored.** Variants are generated on the first request instead of at upload time                |
+| `prewarmedUrls` / `queuedTransformationUrls`   | Never returned, for the same reason                                                              |
+| `maxSize`                                      | Component default is 50 MB. Cloud has no server-side size setting, raise it only after testing the sizes you need |
+| Destination folder                             | Always the one in the signature. `folder` set on the component is ignored when a signature is used |
+
+## Handling quota errors
+
+An upload that would push the account past its storage allowance is refused with
+`402` and a JSON body naming the feature. Surface it, don't retry it, the retry
+will fail identically until the plan or the usage changes.
+
+```tsx
+<FileUploader
+  sign={sign}
+  onError={({ message }) => {
+    // "Storage limit reached on the Free plan. …"
+    toast.error(message);
+  }}
+/>
+```
+
+See [Errors](/cloud/api#errors) and [Plans and
+limits](/cloud/overview#plans-and-limits).
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="signUpload throws 'Failed to sign upload (HTTP 404)'">
+    `NEXT_PUBLIC_OPENINARY_URL` probably still ends in `/api`, that suffix is a
+    self-hosted full-stack thing. On Cloud the API is at the root:
+    `https://cdn.openinary.dev`.
+  </Accordion>
+  <Accordion title="401 on POST /upload/sign">
+    The API key is missing, disabled, expired, or you're calling the endpoint from
+    the browser (where the key shouldn't be at all). Check `OPENINARY_API_KEY` on
+    your backend, and that the key is still enabled in **Settings → API keys**.
+  </Accordion>
+  <Accordion title="401 'Invalid or expired upload signature'">
+    The token's `expires` passed before the upload started, or the signature was
+    altered. Raise `expiresIn` a little (the server clamps it to 3600s). The
+    component always re-signs on retry, so this shouldn't survive a retry.
+  </Accordion>
+  <Accordion title="402 quota_exceeded">
+    A plan allowance ran out. `feature` in the body says which one. Storage is
+    cumulative, deleting files frees it back; everything else resets monthly.
+  </Accordion>
+  <Accordion title="Files land in the wrong folder">
+    On Cloud the destination comes from the **signature**, not the component. Fix
+    the `folder` you pass to `signUpload` on your backend.
+  </Accordion>
+  <Accordion title="CORS error in the console">
+    `POST /upload` accepts token-authenticated uploads from any origin, so a CORS
+    failure here usually means the request isn't the one you think, e.g. your code
+    is calling `/upload/sign` or `/storage` from the browser. Those are
+    backend-only endpoints. Move the call server-side.
+  </Accordion>
+</AccordionGroup>

--- a/docs/cloud/overview.mdx
+++ b/docs/cloud/overview.mdx
@@ -23,8 +23,8 @@ key, and start uploading.
 
 ## Two hostnames
 
-| Host                     | What it is                                                             |
-| ------------------------ | ---------------------------------------------------------------------- |
+| Host                        | What it is                                                              |
+| --------------------------- | ----------------------------------------------------------------------- |
 | `https://app.openinary.dev` | Dashboard, sign-in, media browser, API keys, buckets, usage and billing |
 | `https://cdn.openinary.dev` | The API you call, and the CDN your assets are delivered from            |
 
@@ -46,10 +46,11 @@ https://cdn.openinary.dev/b/{bucketId}/t/{transformations}/{path}
     is ready"* with a sign-in link. The link is valid for **24 hours**.
   </Step>
   <Step title="Sign in">
-    The link drops you straight into [app.openinary.dev](https://app.openinary.dev),
-    already signed in. Afterwards, sign in from the same page with a **6-digit
-    code** sent to your email (valid 10 minutes), or with **Google** if that
-    address matches your account.
+    The link drops you straight into
+    [app.openinary.dev](https://app.openinary.dev), already signed in.
+    Afterwards, sign in from the same page with a **6-digit code** sent to your
+    email (valid 10 minutes), or with **Google** if that address matches your
+    account.
   </Step>
 </Steps>
 
@@ -81,19 +82,19 @@ Every account starts on **Free**. **Early Access** doubles the allowances, costs
 nothing per month, and adds pay-as-you-go past them (a card is collected at
 checkout so overage can be billed). Upgrade from **Settings → Plan**.
 
-| Included per month     | Free       | Early Access | Past the allowance |
-| ---------------------- | ---------- | ------------ | ------------------ |
-| Storage                | 1 GB       | 2 GB         | $0.03 / extra GB   |
-| Image transformations  | 500        | 1,000        | $0.40 / 1,000      |
-| Video processing       | 15 min     | 30 min       | $0.01 / min        |
-| CDN requests           | 25,000     | 50,000       | $0.50 / 100,000    |
-| Buckets                | 1          | 2            | —                  |
+| Included per month    | Free   | Early Access | Past the allowance |
+| --------------------- | ------ | ------------ | ------------------ |
+| Storage               | 1 GB   | 2 GB         | $0.03 / extra GB   |
+| Image transformations | 500    | 1,000        | $0.40 / 1,000      |
+| Video processing      | 15 min | 30 min       | $0.01 / min        |
+| CDN requests          | 25,000 | 50,000       | $0.50 / 100,000    |
+| Buckets               | 1      | 2            | —                  |
 
 <Note>
   On Free, hitting a limit returns [`402`](/cloud/api#errors) until the monthly
-  allowance resets (storage is cumulative, it doesn't reset). Video processing is
-  metered on how long the transform actually took to run, not on the length of
-  the video. Cached deliveries never count as transformations.
+  allowance resets (storage is cumulative, it doesn't reset). Video processing
+  is metered on how long the transform actually took to run, not on the length
+  of the video. Cached deliveries never count as transformations.
 </Note>
 
 Live usage, the deliveries behind each number, and your video jobs are in
@@ -104,15 +105,15 @@ Live usage, the deliveries behind each number, and your video jobs are in
 Almost nothing, at the level you write code, the transformation syntax is
 identical. The differences worth knowing:
 
-| Topic                | Self-hosted                          | Cloud                                                            |
-| -------------------- | ------------------------------------ | ---------------------------------------------------------------- |
-| Delivery URL         | `/t/{transformations}/{path}`        | `/b/{bucketId}/t/{transformations}/{path}`                       |
-| API keys             | Created via the dashboard or the API | Dashboard only, and each key is pinned to one bucket             |
-| Multi-tenancy        | One storage root                     | Buckets, isolated per account                                    |
-| Limits               | Your hardware                        | Plan allowances, `402` past them                                 |
-| Signed delivery URLs | `/authenticated/s--{sig}/…`          | Not available yet                                                |
-| Prewarm on upload    | `transformations` field on `/upload` | Ignored, variants are generated on the first request             |
-| Queue admin API      | `/queue/stats`, `/queue/jobs`, …     | Only `/queue/events` and `/video-status/{path}`                  |
+| Topic                | Self-hosted                          | Cloud                                                |
+| -------------------- | ------------------------------------ | ---------------------------------------------------- |
+| Delivery URL         | `/t/{transformations}/{path}`        | `/b/{bucketId}/t/{transformations}/{path}`           |
+| API keys             | Created via the dashboard or the API | Dashboard only, and each key is pinned to one bucket |
+| Multi-tenancy        | One storage root                     | Buckets, isolated per account                        |
+| Limits               | Your hardware                        | Plan allowances, `402` past them                     |
+| Signed delivery URLs | `/authenticated/s--{sig}/…`          | Not available yet                                    |
+| Prewarm on upload    | `transformations` field on `/upload` | Not available yet                                    |
+| Queue admin API      | `/queue/stats`, `/queue/jobs`, …     | Only `/queue/events` and `/video-status/{path}`      |
 
 ## Next steps
 
@@ -123,7 +124,11 @@ identical. The differences worth knowing:
   <Card title="Cloud API Reference" icon="code" href="/cloud/api">
     Base URL, authentication, every endpoint, errors and rate limits.
   </Card>
-  <Card title="File Uploader on Cloud" icon="puzzle-piece" href="/cloud/file-uploader">
+  <Card
+    title="File Uploader on Cloud"
+    icon="puzzle-piece"
+    href="/cloud/file-uploader"
+  >
     Drop the React uploader into your app, no API key in the browser.
   </Card>
   <Card

--- a/docs/cloud/overview.mdx
+++ b/docs/cloud/overview.mdx
@@ -1,0 +1,136 @@
+---
+title: "Openinary Cloud"
+sidebarTitle: "Overview"
+description: "Managed Openinary, hosted for you. Same transformation API, same upload API, no server to run. Currently in early access."
+---
+
+Openinary Cloud is the hosted version of Openinary. You get the same URL-based
+transformation API and the same upload API as the [self-hosted](/quickstart)
+version, without running Docker, storage, or a video worker yourself.
+
+<Note>
+  Cloud is in **early access**. Sign-up is not open: accounts are opened one by
+  one from the request list. See [Request access](#request-access) below.
+</Note>
+
+## What you don't have to do
+
+Everything the self-hosted docs ask you to configure, Cloud already runs:
+storage, the transform pipeline, the video processing queue, the CDN cache, and
+the dashboard. There are no environment variables, no `API_SECRET`, no
+`CORS_ORIGIN`, no Docker resources to size. You create an account, create an API
+key, and start uploading.
+
+## Two hostnames
+
+| Host                     | What it is                                                             |
+| ------------------------ | ---------------------------------------------------------------------- |
+| `https://app.openinary.dev` | Dashboard, sign-in, media browser, API keys, buckets, usage and billing |
+| `https://cdn.openinary.dev` | The API you call, and the CDN your assets are delivered from            |
+
+Your public asset URLs always look like this:
+
+```
+https://cdn.openinary.dev/b/{bucketId}/t/{transformations}/{path}
+```
+
+## Request access
+
+<Steps>
+  <Step title="Ask for an invite">
+    Open [openinary.dev](https://openinary.dev), click **Request Cloud access**,
+    and leave your email address.
+  </Step>
+  <Step title="Wait for the invite email">
+    When your account is opened you get an email titled *"Your Openinary account
+    is ready"* with a sign-in link. The link is valid for **24 hours**.
+  </Step>
+  <Step title="Sign in">
+    The link drops you straight into [app.openinary.dev](https://app.openinary.dev),
+    already signed in. Afterwards, sign in from the same page with a **6-digit
+    code** sent to your email (valid 10 minutes), or with **Google** if that
+    address matches your account.
+  </Step>
+</Steps>
+
+<Warning>
+  There is no password and no self-service sign-up. If the sign-in page says it
+  can't send a code, the address isn't on an account yet, request access first.
+  If your invite link expired, just request a code from the sign-in page: your
+  account already exists.
+</Warning>
+
+## Buckets
+
+A **bucket** is an isolated space for your media. Files, folders, and cached
+transforms never cross between buckets, and each bucket has its own `bucketId`
+in your delivery URLs, so a staging bucket can't serve a production asset.
+
+- One bucket is **active** at a time in the dashboard, that's the one the media
+  browser shows.
+- **API keys are pinned to a single bucket** when you create them, and can't be
+  re-scoped afterwards. What an integration writes to therefore never depends on
+  what's selected in the dashboard.
+- Deleting a bucket deletes its files and every API key pinned to it.
+
+Manage them in the dashboard under **Settings → Buckets**.
+
+## Plans and limits
+
+Every account starts on **Free**. **Early Access** doubles the allowances, costs
+nothing per month, and adds pay-as-you-go past them (a card is collected at
+checkout so overage can be billed). Upgrade from **Settings → Plan**.
+
+| Included per month     | Free       | Early Access | Past the allowance |
+| ---------------------- | ---------- | ------------ | ------------------ |
+| Storage                | 1 GB       | 2 GB         | $0.03 / extra GB   |
+| Image transformations  | 500        | 1,000        | $0.40 / 1,000      |
+| Video processing       | 15 min     | 30 min       | $0.01 / min        |
+| CDN requests           | 25,000     | 50,000       | $0.50 / 100,000    |
+| Buckets                | 1          | 2            | —                  |
+
+<Note>
+  On Free, hitting a limit returns [`402`](/cloud/api#errors) until the monthly
+  allowance resets (storage is cumulative, it doesn't reset). Video processing is
+  metered on how long the transform actually took to run, not on the length of
+  the video. Cached deliveries never count as transformations.
+</Note>
+
+Live usage, the deliveries behind each number, and your video jobs are in
+**Settings → Usage** and **Settings → Plan**.
+
+## What's different from self-hosted
+
+Almost nothing, at the level you write code, the transformation syntax is
+identical. The differences worth knowing:
+
+| Topic                | Self-hosted                          | Cloud                                                            |
+| -------------------- | ------------------------------------ | ---------------------------------------------------------------- |
+| Delivery URL         | `/t/{transformations}/{path}`        | `/b/{bucketId}/t/{transformations}/{path}`                       |
+| API keys             | Created via the dashboard or the API | Dashboard only, and each key is pinned to one bucket             |
+| Multi-tenancy        | One storage root                     | Buckets, isolated per account                                    |
+| Limits               | Your hardware                        | Plan allowances, `402` past them                                 |
+| Signed delivery URLs | `/authenticated/s--{sig}/…`          | Not available yet                                                |
+| Prewarm on upload    | `transformations` field on `/upload` | Ignored, variants are generated on the first request             |
+| Queue admin API      | `/queue/stats`, `/queue/jobs`, …     | Only `/queue/events` and `/video-status/{path}`                  |
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Cloud Quickstart" icon="bolt" href="/cloud/quickstart">
+    Create an API key, upload a file, and deliver your first transformed URL.
+  </Card>
+  <Card title="Cloud API Reference" icon="code" href="/cloud/api">
+    Base URL, authentication, every endpoint, errors and rate limits.
+  </Card>
+  <Card title="File Uploader on Cloud" icon="puzzle-piece" href="/cloud/file-uploader">
+    Drop the React uploader into your app, no API key in the browser.
+  </Card>
+  <Card
+    title="Transformations"
+    icon="wand-magic-sparkles"
+    href="/media-transformations/overview"
+  >
+    The full parameter list, shared with the self-hosted version.
+  </Card>
+</CardGroup>

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -41,10 +41,12 @@ Your key is what lets your backend talk to `https://cdn.openinary.dev`.
     **API keys**.
   </Step>
   <Step title="Fill in the three fields">
-    - **Name**, so you can tell keys apart later, e.g. `Production`. -
-    **Bucket**, the one this key can read and write. It **cannot be changed
-    later**, create a second key rather than re-pointing this one. -
-    **Expires**, in days, from 1 to 365 (default 365).
+
+    - **Name**, so you can tell keys apart later, e.g. `Production`.
+    - **Bucket**, the one this key can read and write. It **cannot be changed
+      later**, create a second key rather than re-pointing this one.
+    - **Expires**, in days, from 1 to 365 (default 365).
+
   </Step>
   <Step title="Copy the key immediately">
     The key (`oik_…`) is displayed **once**, right after creation. Store it in
@@ -126,13 +128,25 @@ https://cdn.openinary.dev/b/{bucketId}/t/w_400,h_400,c_fill/products/photo.jpg
 
 <Tabs>
   <Tab title="Thumbnail">
-    ``` /b/{bucketId}/t/w_400,h_400,c_fill/products/photo.jpg ```
+
+    ```
+    /b/{bucketId}/t/w_400,h_400,c_fill/products/photo.jpg
+    ```
+
   </Tab>
   <Tab title="WebP at quality 80">
-    ``` /b/{bucketId}/t/w_1200,f_webp,q_80/products/photo.jpg ```
+
+    ```
+    /b/{bucketId}/t/w_1200,f_webp,q_80/products/photo.jpg
+    ```
+
   </Tab>
   <Tab title="Original, untransformed">
-    ``` /b/{bucketId}/t/products/photo.jpg ```
+
+    ```
+    /b/{bucketId}/t/products/photo.jpg
+    ```
+
   </Tab>
 </Tabs>
 

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -12,17 +12,18 @@ Cloud is in early access, so accounts are opened manually.
 
 <Steps>
   <Step title="Request access">
-    On [openinary.dev](https://openinary.dev), click **Request Cloud access** and
-    leave your email address.
+    On [openinary.dev](https://openinary.dev), click **Request Cloud access**
+    and leave your email address.
   </Step>
-  <Step title="Open the invite email">
+  <Step title="Wait for the invite email">
     When your account is opened you receive *"Your Openinary account is ready"*
     with a sign-in link, valid for 24 hours. Clicking it signs you in at
     [app.openinary.dev](https://app.openinary.dev).
   </Step>
   <Step title="Sign back in later">
-    From [app.openinary.dev](https://app.openinary.dev), enter your email to get a
-    **6-digit code** (valid 10 minutes), or use **Google**. There is no password.
+    From [app.openinary.dev](https://app.openinary.dev), enter your email to get
+    a **6-digit code** (valid 10 minutes), or use **Google**. There is no
+    password.
   </Step>
 </Steps>
 
@@ -36,14 +37,14 @@ Your key is what lets your backend talk to `https://cdn.openinary.dev`.
 
 <Steps>
   <Step title="Open the API keys tab">
-    Click your account in the bottom-left of the dashboard → **Settings** → **API
-    keys**.
+    Click your account in the bottom-left of the dashboard → **Settings** →
+    **API keys**.
   </Step>
   <Step title="Fill in the three fields">
-    - **Name**, so you can tell keys apart later, e.g. `Production`.
-    - **Bucket**, the one this key can read and write. It **cannot be changed
-      later**, create a second key rather than re-pointing this one.
-    - **Expires**, in days, from 1 to 365 (default 365).
+    - **Name**, so you can tell keys apart later, e.g. `Production`. -
+    **Bucket**, the one this key can read and write. It **cannot be changed
+    later**, create a second key rather than re-pointing this one. -
+    **Expires**, in days, from 1 to 365 (default 365).
   </Step>
   <Step title="Copy the key immediately">
     The key (`oik_…`) is displayed **once**, right after creation. Store it in
@@ -54,8 +55,8 @@ Your key is what lets your backend talk to `https://cdn.openinary.dev`.
 <Warning>
   Treat the key like a password. It writes to, and deletes from, your bucket.
   Keep it **server-side only**, never ship it in a browser bundle, a mobile app,
-  or a public repo. For browser uploads use
-  [presigned signatures](/cloud/file-uploader) instead.
+  or a public repo. For browser uploads use [presigned
+  signatures](/cloud/file-uploader) instead.
 </Warning>
 
 You can disable a key temporarily (**Power** icon) or delete it outright at any
@@ -125,19 +126,13 @@ https://cdn.openinary.dev/b/{bucketId}/t/w_400,h_400,c_fill/products/photo.jpg
 
 <Tabs>
   <Tab title="Thumbnail">
-    ```
-    /b/{bucketId}/t/w_400,h_400,c_fill/products/photo.jpg
-    ```
+    ``` /b/{bucketId}/t/w_400,h_400,c_fill/products/photo.jpg ```
   </Tab>
   <Tab title="WebP at quality 80">
-    ```
-    /b/{bucketId}/t/w_1200,f_webp,q_80/products/photo.jpg
-    ```
+    ``` /b/{bucketId}/t/w_1200,f_webp,q_80/products/photo.jpg ```
   </Tab>
   <Tab title="Original, untransformed">
-    ```
-    /b/{bucketId}/t/products/photo.jpg
-    ```
+    ``` /b/{bucketId}/t/products/photo.jpg ```
   </Tab>
 </Tabs>
 
@@ -211,9 +206,9 @@ NEXT_PUBLIC_OPENINARY_BUCKET=1f0c7a2e-...  # public, it's in every URL
 <Warning>
   Don't let users upload straight to `/upload` with your API key proxied through
   a public route, that's the same as leaking the key. Either upload from a
-  server route you authenticate yourself (above), or use
-  [presigned signatures](/cloud/file-uploader) so the browser only ever holds a
-  short-lived token.
+  server route you authenticate yourself (above), or use [presigned
+  signatures](/cloud/file-uploader) so the browser only ever holds a short-lived
+  token.
 </Warning>
 
 ## Videos
@@ -254,7 +249,11 @@ curl "https://cdn.openinary.dev/video-status/w_640/clips/demo.mp4" \
   >
     The complete parameter reference.
   </Card>
-  <Card title="Plans & limits" icon="gauge" href="/cloud/overview#plans-and-limits">
+  <Card
+    title="Plans & limits"
+    icon="gauge"
+    href="/cloud/overview#plans-and-limits"
+  >
     What's included, and what happens past it.
   </Card>
 </CardGroup>

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -1,0 +1,260 @@
+---
+title: "Cloud Quickstart"
+description: "Create your Openinary Cloud account, mint an API key, upload your first file, and deliver a transformed URL, in about five minutes."
+---
+
+By the end of this page you'll have an account, an API key that works from your
+backend, a file in storage, and a public URL that resizes it on the fly.
+
+## 1. Create your account
+
+Cloud is in early access, so accounts are opened manually.
+
+<Steps>
+  <Step title="Request access">
+    On [openinary.dev](https://openinary.dev), click **Request Cloud access** and
+    leave your email address.
+  </Step>
+  <Step title="Open the invite email">
+    When your account is opened you receive *"Your Openinary account is ready"*
+    with a sign-in link, valid for 24 hours. Clicking it signs you in at
+    [app.openinary.dev](https://app.openinary.dev).
+  </Step>
+  <Step title="Sign back in later">
+    From [app.openinary.dev](https://app.openinary.dev), enter your email to get a
+    **6-digit code** (valid 10 minutes), or use **Google**. There is no password.
+  </Step>
+</Steps>
+
+<Check>
+  Signed in, you land on the media browser for your default bucket, **Main**.
+</Check>
+
+## 2. Create an API key
+
+Your key is what lets your backend talk to `https://cdn.openinary.dev`.
+
+<Steps>
+  <Step title="Open the API keys tab">
+    Click your account in the bottom-left of the dashboard → **Settings** → **API
+    keys**.
+  </Step>
+  <Step title="Fill in the three fields">
+    - **Name**, so you can tell keys apart later, e.g. `Production`.
+    - **Bucket**, the one this key can read and write. It **cannot be changed
+      later**, create a second key rather than re-pointing this one.
+    - **Expires**, in days, from 1 to 365 (default 365).
+  </Step>
+  <Step title="Copy the key immediately">
+    The key (`oik_…`) is displayed **once**, right after creation. Store it in
+    your secret manager or `.env` now, there is no way to read it back.
+  </Step>
+</Steps>
+
+<Warning>
+  Treat the key like a password. It writes to, and deletes from, your bucket.
+  Keep it **server-side only**, never ship it in a browser bundle, a mobile app,
+  or a public repo. For browser uploads use
+  [presigned signatures](/cloud/file-uploader) instead.
+</Warning>
+
+You can disable a key temporarily (**Power** icon) or delete it outright at any
+time, both take effect immediately.
+
+## 3. Upload a file
+
+Send the key as `x-api-key`, or as `Authorization: Bearer`, either works.
+
+<Tabs>
+  <Tab title="curl">
+    ```bash
+    curl -X POST https://cdn.openinary.dev/upload \
+      -H "x-api-key: $OPENINARY_API_KEY" \
+      -F "files=@photo.jpg" \
+      -F "folder=products"
+    ```
+  </Tab>
+  <Tab title="Node.js">
+    ```ts
+    const form = new FormData();
+    form.append("files", new Blob([await readFile("photo.jpg")]), "photo.jpg");
+    form.append("folder", "products");
+
+    const res = await fetch("https://cdn.openinary.dev/upload", {
+      method: "POST",
+      headers: { "x-api-key": process.env.OPENINARY_API_KEY! },
+      body: form,
+    });
+    const { files } = await res.json();
+    ```
+
+  </Tab>
+</Tabs>
+
+The response tells you where the file landed, and gives you your delivery path:
+
+```json
+{
+  "success": true,
+  "files": [
+    {
+      "path": "products/photo.jpg",
+      "name": "photo.jpg",
+      "filename": "photo.jpg",
+      "size": 248713,
+      "url": "/b/1f0c7a2e-5b64-4d0a-9b1a-6f2d9c33e871/t/products/photo.jpg"
+    }
+  ]
+}
+```
+
+<Note>
+  That `url` is where your **bucket ID** comes from, it's the `/b/{bucketId}/`
+  segment. You can also read it off any file's URL in the dashboard's asset
+  details panel. It's not a secret: it's in every public URL you serve.
+</Note>
+
+## 4. Deliver it, transformed
+
+Prefix the returned `url` with `https://cdn.openinary.dev` and insert
+transformation parameters right after `/t/`:
+
+```
+https://cdn.openinary.dev/b/{bucketId}/t/w_400,h_400,c_fill/products/photo.jpg
+```
+
+<Tabs>
+  <Tab title="Thumbnail">
+    ```
+    /b/{bucketId}/t/w_400,h_400,c_fill/products/photo.jpg
+    ```
+  </Tab>
+  <Tab title="WebP at quality 80">
+    ```
+    /b/{bucketId}/t/w_1200,f_webp,q_80/products/photo.jpg
+    ```
+  </Tab>
+  <Tab title="Original, untransformed">
+    ```
+    /b/{bucketId}/t/products/photo.jpg
+    ```
+  </Tab>
+</Tabs>
+
+The first request runs the transformation; every later request is served from
+the CDN cache. The parameter list is exactly the same as the self-hosted version,
+see [Image transformations](/media-transformations/image-transformations) and
+[Video transformations](/media-transformations/video-transformations).
+
+<Check>
+  Open that URL in a browser. If you see your resized image, everything is wired
+  up.
+</Check>
+
+## 5. Use it in a real app
+
+The pattern that holds in production: **uploads and storage calls run on your
+server** with the API key, **delivery URLs are public** and go straight to the
+CDN.
+
+```ts app/api/products/route.ts
+// Server-side: the key never reaches the browser.
+const CDN = "https://cdn.openinary.dev";
+
+export async function POST(request: Request) {
+  const incoming = await request.formData();
+  const file = incoming.get("file");
+  if (!(file instanceof File)) {
+    return Response.json({ error: "No file" }, { status: 400 });
+  }
+
+  const form = new FormData();
+  form.append("files", file, file.name);
+  form.append("folder", "products");
+
+  const res = await fetch(`${CDN}/upload`, {
+    method: "POST",
+    headers: { "x-api-key": process.env.OPENINARY_API_KEY! },
+    body: form,
+  });
+  if (!res.ok) {
+    // 402 means a plan limit was reached, see /cloud/api#errors
+    return Response.json(await res.json(), { status: res.status });
+  }
+
+  const { files } = await res.json();
+  // Store the path; build URLs from it wherever you render.
+  return Response.json({ path: files[0].path, url: `${CDN}${files[0].url}` });
+}
+```
+
+```tsx components/product-image.tsx
+// Client-side: public URLs only, no key involved.
+export function ProductImage({ path }: { path: string }) {
+  const base = `https://cdn.openinary.dev/b/${process.env.NEXT_PUBLIC_OPENINARY_BUCKET}/t`;
+  return (
+    <img
+      src={`${base}/w_800,c_fill,f_webp/${path}`}
+      srcSet={`${base}/w_400,c_fill,f_webp/${path} 400w, ${base}/w_800,c_fill,f_webp/${path} 800w`}
+      sizes="(max-width: 640px) 400px, 800px"
+      alt=""
+    />
+  );
+}
+```
+
+```bash .env
+OPENINARY_API_KEY=oik_...                  # server only
+NEXT_PUBLIC_OPENINARY_BUCKET=1f0c7a2e-...  # public, it's in every URL
+```
+
+<Warning>
+  Don't let users upload straight to `/upload` with your API key proxied through
+  a public route, that's the same as leaking the key. Either upload from a
+  server route you authenticate yourself (above), or use
+  [presigned signatures](/cloud/file-uploader) so the browser only ever holds a
+  short-lived token.
+</Warning>
+
+## Videos
+
+Videos work the same way, with one difference: a transformation is processed
+asynchronously. The first request for a transformed video returns `202` while it
+encodes; poll the status endpoint (or listen to
+[`/queue/events`](/cloud/api#video-processing)) until it's `completed`.
+
+```bash
+curl "https://cdn.openinary.dev/video-status/w_640/clips/demo.mp4" \
+  -H "x-api-key: $OPENINARY_API_KEY"
+```
+
+```json
+{ "status": "running", "progress": 62 }
+```
+
+<Note>
+  A video URL with **no** parameters (`/t/clips/demo.mp4`) is never transcoded,
+  it streams the stored file, with range requests, so seeking works. Transcoding
+  only happens when the URL asks for it.
+</Note>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Cloud API Reference" icon="code" href="/cloud/api">
+    Every endpoint, authentication, errors and rate limits.
+  </Card>
+  <Card title="File Uploader" icon="puzzle-piece" href="/cloud/file-uploader">
+    A ready-made React uploader wired to your Cloud bucket.
+  </Card>
+  <Card
+    title="Transformations"
+    icon="wand-magic-sparkles"
+    href="/media-transformations/overview"
+  >
+    The complete parameter reference.
+  </Card>
+  <Card title="Plans & limits" icon="gauge" href="/cloud/overview#plans-and-limits">
+    What's included, and what happens past it.
+  </Card>
+</CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -18,7 +18,7 @@
   "navigation": {
     "tabs": [
       {
-        "tab": "Documentation",
+        "tab": "Self Host",
         "groups": [
           {
             "group": "Getting Started",
@@ -26,16 +26,6 @@
             "pages": [
               "index",
               "quickstart"
-            ]
-          },
-          {
-            "group": "Openinary Cloud",
-            "icon": "cloud",
-            "pages": [
-              "cloud/overview",
-              "cloud/quickstart",
-              "cloud/api",
-              "cloud/file-uploader"
             ]
           },
           {
@@ -71,6 +61,15 @@
               "cloudinary-comparison"
             ]
           }
+        ]
+      },
+      {
+        "tab": "Cloud",
+        "pages": [
+          "cloud/overview",
+          "cloud/quickstart",
+          "cloud/api",
+          "cloud/file-uploader"
         ]
       },
       {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -29,6 +29,16 @@
             ]
           },
           {
+            "group": "Openinary Cloud",
+            "icon": "cloud",
+            "pages": [
+              "cloud/overview",
+              "cloud/quickstart",
+              "cloud/api",
+              "cloud/file-uploader"
+            ]
+          },
+          {
             "group": "Configuration",
             "icon": "gear",
             "pages": [

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -7,26 +7,18 @@
     "light": "#FFFFFF"
   },
   "contextual": {
-    "options": [
-      "copy",
-      "chatgpt",
-      "claude",
-      "cursor"
-    ]
+    "options": ["copy", "chatgpt", "claude", "cursor"]
   },
   "favicon": "/favicon.svg",
   "navigation": {
     "tabs": [
       {
-        "tab": "Self Host",
+        "tab": "Self-hosted",
         "groups": [
           {
             "group": "Getting Started",
             "icon": "rocket",
-            "pages": [
-              "index",
-              "quickstart"
-            ]
+            "pages": ["index", "quickstart"]
           },
           {
             "group": "Configuration",
@@ -64,7 +56,7 @@
         ]
       },
       {
-        "tab": "Cloud",
+        "tab": "Cloud Managed",
         "pages": [
           "cloud/overview",
           "cloud/quickstart",
@@ -87,9 +79,7 @@
           {
             "group": "Components",
             "icon": "puzzle-piece",
-            "pages": [
-              "guides/file-uploader"
-            ]
+            "pages": ["guides/file-uploader"]
           }
         ]
       },
@@ -99,9 +89,7 @@
           {
             "group": "Overview",
             "icon": "code",
-            "pages": [
-              "api-reference/introduction"
-            ]
+            "pages": ["api-reference/introduction"]
           },
           {
             "group": "Media",
@@ -139,9 +127,7 @@
           {
             "group": "Cache",
             "icon": "rotate",
-            "pages": [
-              "api-reference/cache/invalidate"
-            ]
+            "pages": ["api-reference/cache/invalidate"]
           },
           {
             "group": "Video Processing",
@@ -167,9 +153,7 @@
           {
             "group": "System",
             "icon": "server",
-            "pages": [
-              "api-reference/health"
-            ]
+            "pages": ["api-reference/health"]
           }
         ]
       },

--- a/docs/guides/file-uploader.mdx
+++ b/docs/guides/file-uploader.mdx
@@ -5,6 +5,11 @@ description: "Drop a secure, ready-to-use file uploader into any React app with 
 
 The **Openinary File Uploader** is a shadcn/ui-compatible React component that lets your users upload media directly to your self-hosted Openinary instance. It ships with drag & drop, per-file progress, previews, retry, cancel, and client-side validation.
 
+<Note>
+  On Openinary Cloud the same component works with a different configuration, see
+  [File Uploader on Cloud](/cloud/file-uploader).
+</Note>
+
 It installs the same way as any shadcn component:
 
 ```bash

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -5,11 +5,16 @@ description: "Self-hosted, open-source alternative to Cloudinary. Resize, crop, 
 
 Openinary is an open-source alternative to Cloudinary. Upload your media, then transform it on demand via URL, resize, crop, convert formats, trim video, and more. Runs anywhere Docker runs.
 
+Prefer not to run it yourself? [Openinary Cloud](/cloud/overview) is the hosted version, same API, no server to manage. It's currently in early access.
+
 ## Get started
 
 <CardGroup cols={2}>
   <Card title="Quick Start" icon="bolt" href="/quickstart">
     Run Openinary locally with Docker in a few commands.
+  </Card>
+  <Card title="Openinary Cloud" icon="cloud" href="/cloud/overview">
+    Use the hosted version, create an account, an API key, and ship.
   </Card>
   <Card
     title="Media Transformations"

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -3,6 +3,11 @@ title: "Quick Start"
 description: "Install Openinary with one command, create an admin account, and make your first image transformation."
 ---
 
+<Note>
+  This page covers the **self-hosted** version. For the hosted one, see the
+  [Cloud Quickstart](/cloud/quickstart).
+</Note>
+
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) 20.x or higher


### PR DESCRIPTION
The docs only described the self-hosted version. This adds a **Cloud Managed** tab covering what an early-access user needs to get going, written from the `openinary-cloud` implementation (worker routes, better-auth config, oRPC routers, Autumn limits).

## New pages

| Page | Contents |
| --- | --- |
| `cloud/overview` | What Cloud is, the two hostnames (`app.` / `cdn.openinary.dev`), request access → invite → 6-digit code, buckets, Free vs Early Access limits, differences vs self-hosted |
| `cloud/quickstart` | Create the account → create an API key → upload (curl/Node) → transformed URL → a real Next.js setup (key server-side, public delivery URLs) → videos |
| `cloud/api` | Base URL, `x-api-key` / `Bearer`, every endpoint, presigned uploads, storage, video status, errors incl. the `402 quota_exceeded` body, rate limits, what has no Cloud equivalent |
| `cloud/file-uploader` | Cloud wiring for the `@openinary/file-uploader` component: no `/api` suffix, no `API_SECRET`/`CORS_ORIGIN`, `url` shaped `/b/{bucketId}/t/...`, signing endpoint, troubleshooting. Links to the existing guide for props and styling |

## Navigation

- `Documentation` tab renamed **Self-hosted**; new **Cloud Managed** tab beside it.
- Four orientation notes added to existing pages (`index`, `quickstart`, `api-reference/introduction`, `guides/file-uploader`) so self-hosted and Cloud stop being confusable.

## Cloud-specific behaviour documented

- `transformations` (prewarm at upload) is ignored on Cloud, variants are generated on first request.
- Signed delivery URLs (`/authenticated/…`) don't exist on Cloud yet.
- API keys are pinned to a single bucket at creation and are dashboard-only.
- Only `POST /upload` accepts a third-party origin; every other endpoint is backend-only.

Cloud's $20/mo plan is deliberately **not** documented, `CLOUD_AVAILABLE` is still `false`, so only Free and Early Access appear.

Verified with `mint broken-links` (clean) and by rendering every page in a local `mint dev` preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)