### PR TITLE
feat(core): store and deliver audio & 3D as pass-through originals

### DIFF
--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -11,6 +11,7 @@ import {
   generateUploadSignature,
   stripUrlHostile,
   validateUploadFileType,
+  allowedUploadExtensions,
   logger,
   serializeError,
   type RouteDeps,
@@ -441,7 +442,7 @@ export function createUploadRoute(deps: RouteDeps) {
         if (!validateUploadFileType(filename, mimeType)) {
           failedUploads.push({
             filename: rawSanitizedPath,
-            error: `Invalid file type: ${mimeType}. Allowed types: images (jpg, jpeg, png, webp, avif, gif, heic, heif, psd) and videos (mp4, mov, webm)`,
+            error: `Invalid file type: ${mimeType}. Allowed extensions: ${allowedUploadExtensions().join(", ")}`,
           });
           continue;
         }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,8 @@ export {
   ALLOWED_UPLOAD_TYPES,
   stripUrlHostile,
   validateUploadFileType,
+  contentTypeForExt,
+  allowedUploadExtensions,
 } from "./utils/upload-validation";
 export { deleteAssetCompletely, type DeleteAssetResult } from "./utils/asset-deletion";
 export { default as logger, serializeError } from "./utils/logger";

--- a/packages/core/src/services/transform.service.test.ts
+++ b/packages/core/src/services/transform.service.test.ts
@@ -132,3 +132,23 @@ test("q_auto opts a video into transformation", async () => {
   assert.equal(result.status, 202);
   assert.equal(result.stream, undefined);
 });
+
+test("a bare audio/3D URL streams the original with its real content-type", async () => {
+  const service = new TransformService(fakeStorage(), fakeQueue());
+
+  const glb = await service.transform({
+    path: "/t/models/duck.glb",
+    userAgent: "",
+    context: {} as any,
+  });
+  assert.ok(glb.stream, "glb original should be streamed");
+  assert.equal(glb.contentType, "model/gltf-binary");
+
+  const wav = await service.transform({
+    path: "/t/audio/sfx.wav",
+    userAgent: "",
+    context: {} as any,
+  });
+  assert.ok(wav.stream, "wav original should be streamed");
+  assert.equal(wav.contentType, "audio/wav");
+});

--- a/packages/core/src/services/transform.service.ts
+++ b/packages/core/src/services/transform.service.ts
@@ -110,14 +110,15 @@ export class TransformService {
         throw new Error(fileCheck.error || "File not found");
       }
 
-      // A bare /t/<video> URL delivers the untouched original. Transcoding only
-      // happens when the URL asks for it, either with explicit parameters or
-      // with q_auto for the default optimization.
-      if (isVideo(ext) && Object.keys(effectiveParams).length === 0) {
-        return await this.streamOriginalVideo(
+      // A bare /t/<path> URL delivers the untouched original for any stored type
+      // (video, audio, 3D). Images always carry an auto-selected format at this
+      // point, so they keep optimizing; transcoding only happens when the URL
+      // asks for it, either with explicit parameters or with q_auto.
+      if (Object.keys(effectiveParams).length === 0) {
+        return await this.streamOriginal(
           filePath,
           localPath,
-          ext,
+          ext ?? "",
           sourceUrl,
         );
       }
@@ -551,9 +552,10 @@ export class TransformService {
   /**
    * Stream the untouched original without buffering it in memory: originals can
    * weigh hundreds of MB and buffering both delays the first byte and pressures
-   * the container memory while ffmpeg jobs are running.
+   * the container memory while ffmpeg jobs are running. Serves any stored type
+   * (video, audio, 3D, image) with its real content-type.
    */
-  private async streamOriginalVideo(
+  private async streamOriginal(
     filePath: string,
     localPath: string,
     ext: string,
@@ -563,10 +565,12 @@ export class TransformService {
     // ByteString, and raw file paths can contain non-ASCII or NFD-decomposed
     // accented characters (e.g. a combining accent has a code point > 255)
     const headers: Record<string, string> = {
-      "X-Video-Status": "original",
       "Cache-Control": "public, max-age=31536000, must-revalidate",
       ETag: `"${encodeURIComponent(filePath)}-original"`,
     };
+    if (isVideo(ext)) {
+      headers["X-Video-Status"] = "original";
+    }
 
     try {
       let stream: ReadableStream<Uint8Array>;
@@ -602,9 +606,9 @@ export class TransformService {
     } catch (error) {
       logger.error(
         { error: serializeError(error), filePath },
-        "Failed to serve original video",
+        "Failed to serve original",
       );
-      throw new Error("Failed to load video");
+      throw new Error("Failed to load original");
     }
   }
 

--- a/packages/core/src/utils/format-support.test.ts
+++ b/packages/core/src/utils/format-support.test.ts
@@ -2,7 +2,12 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import { isTransformSegment, parseParams } from "./parser";
-import { IMAGE_FORMATS, VIDEO_FORMATS, determineOutputFormat } from "./video/format";
+import {
+  IMAGE_FORMATS,
+  VIDEO_FORMATS,
+  determineOutputFormat,
+  contentTypeForFormat,
+} from "./video/format";
 
 // The f_ parameter is the trust boundary: every value it lets through must be a
 // format some encoder can actually produce, otherwise we serve bytes of one
@@ -39,4 +44,12 @@ test("video thumbnails resolve to an image format, video transforms to a video o
   assert.equal(determineOutputFormat("mp4", "webm").format, "webm");
   // psd is no longer an image output, so it can't produce a bogus image/psd
   assert.equal(determineOutputFormat("mp4", "psd").isImageOutput, false);
+});
+
+test("contentTypeForFormat serves real types; unknown is octet-stream, never video/mp4", () => {
+  assert.equal(contentTypeForFormat("jpeg"), "image/jpeg");
+  assert.equal(contentTypeForFormat("mp4"), "video/mp4");
+  assert.equal(contentTypeForFormat("glb"), "model/gltf-binary");
+  assert.equal(contentTypeForFormat("wav"), "audio/wav");
+  assert.equal(contentTypeForFormat("xyz"), "application/octet-stream");
 });

--- a/packages/core/src/utils/upload-validation.test.ts
+++ b/packages/core/src/utils/upload-validation.test.ts
@@ -1,6 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { stripUrlHostile } from './upload-validation';
+import {
+  ALLOWED_UPLOAD_TYPES,
+  allowedUploadExtensions,
+  contentTypeForExt,
+  stripUrlHostile,
+  validateUploadFileType,
+} from './upload-validation';
 
 const BASE = 'https://cdn.example.com/t';
 
@@ -63,4 +69,50 @@ test('the raw name does not - which is the bug', () => {
   const url = new URL(`${BASE}/VAULT/The #1 clip.mp4`);
   assert.notEqual(url.hash, '');
   assert.equal(url.pathname.endsWith('.mp4'), false);
+});
+
+test("accepts audio and 3D uploads with the MIME variants browsers send", () => {
+  assert.ok(validateUploadFileType("sfx.wav", "audio/wav"));
+  assert.ok(validateUploadFileType("sfx.wav", "audio/x-wav"));
+  assert.ok(validateUploadFileType("track.mp3", "audio/mpeg"));
+  assert.ok(validateUploadFileType("amb.ogg", "application/ogg"));
+  assert.ok(validateUploadFileType("duck.glb", "model/gltf-binary"));
+  // browsers usually send .glb as octet-stream, the same as .psd
+  assert.ok(validateUploadFileType("duck.glb", "application/octet-stream"));
+  assert.ok(validateUploadFileType("scene.gltf", "model/gltf+json"));
+});
+
+test("still rejects disallowed types and ext/MIME mismatches", () => {
+  assert.ok(!validateUploadFileType("evil.svg", "image/svg+xml"));
+  assert.ok(!validateUploadFileType("clip.wav", "video/mp4"));
+});
+
+test("the existing image/video whitelist is preserved", () => {
+  assert.deepEqual(ALLOWED_UPLOAD_TYPES["image/jpeg"], [".jpg", ".jpeg"]);
+  assert.deepEqual(ALLOWED_UPLOAD_TYPES["image/heic"], [".heic", ".heif"]);
+  assert.deepEqual(ALLOWED_UPLOAD_TYPES["video/mp4"], [".mp4"]);
+  // octet-stream now covers psd + the new 3D types
+  assert.deepEqual(ALLOWED_UPLOAD_TYPES["application/octet-stream"], [
+    ".psd",
+    ".glb",
+    ".gltf",
+  ]);
+});
+
+test("allowedUploadExtensions lists the accepted types for error messages", () => {
+  const exts = allowedUploadExtensions();
+  for (const e of ["glb", "gltf", "wav", "mp3", "ogg", "jpg", "mp4", "psd"]) {
+    assert.ok(exts.includes(e), `${e} should be listed`);
+  }
+  // sorted + de-duplicated (aliases like jpeg/jpg both appear once each)
+  assert.deepEqual(exts, [...new Set(exts)].sort());
+});
+
+test("content-type comes from the same table; unknown falls back to octet-stream", () => {
+  assert.equal(contentTypeForExt("glb"), "model/gltf-binary");
+  assert.equal(contentTypeForExt("wav"), "audio/wav");
+  assert.equal(contentTypeForExt("jpeg"), "image/jpeg"); // alias of jpg
+  assert.equal(contentTypeForExt("mp4"), "video/mp4");
+  assert.equal(contentTypeForExt("xyz"), "application/octet-stream");
+  assert.equal(contentTypeForExt(undefined), "application/octet-stream");
 });

--- a/packages/core/src/utils/upload-validation.ts
+++ b/packages/core/src/utils/upload-validation.ts
@@ -1,29 +1,94 @@
 import path from "path";
 
 /**
- * Single source of truth for what Openinary accepts at upload time.
- * Consumed by the OSS API and the SaaS so their whitelists cannot diverge.
+ * Single source of truth for the media types Openinary handles: what it accepts
+ * at upload time AND the content-type each one is served with. The upload
+ * whitelist and the extension->content-type map are derived from one table so
+ * they cannot drift.
  *
- * Deliberately excludes svg (stored-XSS vector when served inline) and every
- * format the transform pipeline cannot decode.
+ * Consumed by the OSS API and the SaaS so their whitelists cannot diverge.
+ * Deliberately excludes svg (stored-XSS vector when served inline). Images and
+ * videos go through the transform pipeline; audio and 3D are stored and served
+ * as opaque originals (no transform pipeline).
+ */
+interface MediaType {
+  /** canonical extension, no dot, lowercase */
+  ext: string;
+  /** extra extensions that resolve to the same type (e.g. jpeg -> jpg) */
+  aliases?: readonly string[];
+  /** content-type used when serving the stored original */
+  contentType: string;
+  /** MIME values a browser may send for this type at upload (includes contentType) */
+  uploadMimes: readonly string[];
+}
+
+const MEDIA_TYPES: readonly MediaType[] = [
+  // Images
+  { ext: "jpg", aliases: ["jpeg"], contentType: "image/jpeg", uploadMimes: ["image/jpeg"] },
+  { ext: "png", contentType: "image/png", uploadMimes: ["image/png"] },
+  { ext: "webp", contentType: "image/webp", uploadMimes: ["image/webp"] },
+  { ext: "avif", contentType: "image/avif", uploadMimes: ["image/avif"] },
+  { ext: "gif", contentType: "image/gif", uploadMimes: ["image/gif"] },
+  { ext: "heic", aliases: ["heif"], contentType: "image/heic",
+    uploadMimes: ["image/heic", "image/heif"] },
+  { ext: "psd", contentType: "image/vnd.adobe.photoshop",
+    uploadMimes: ["image/vnd.adobe.photoshop", "application/octet-stream"] },
+  // Videos
+  { ext: "mp4", contentType: "video/mp4", uploadMimes: ["video/mp4"] },
+  { ext: "mov", contentType: "video/quicktime", uploadMimes: ["video/quicktime"] },
+  { ext: "webm", contentType: "video/webm", uploadMimes: ["video/webm"] },
+  // Audio (stored + delivered as originals, not transformed)
+  { ext: "wav", contentType: "audio/wav", uploadMimes: ["audio/wav", "audio/x-wav"] },
+  { ext: "mp3", contentType: "audio/mpeg", uploadMimes: ["audio/mpeg"] },
+  { ext: "ogg", contentType: "audio/ogg", uploadMimes: ["audio/ogg", "application/ogg"] },
+  // 3D models (stored + delivered as originals). Browsers usually send .glb as
+  // application/octet-stream, the same as .psd.
+  { ext: "glb", contentType: "model/gltf-binary",
+    uploadMimes: ["model/gltf-binary", "application/octet-stream"] },
+  { ext: "gltf", contentType: "model/gltf+json",
+    uploadMimes: ["model/gltf+json", "application/octet-stream"] },
+];
+
+const CONTENT_TYPE_BY_EXT: Readonly<Record<string, string>> = Object.fromEntries(
+  MEDIA_TYPES.flatMap((t) =>
+    [t.ext, ...(t.aliases ?? [])].map((e) => [e, t.contentType] as const),
+  ),
+);
+
+/**
+ * Upload whitelist derived from the table above: MIME type -> allowed extensions.
  */
 export const ALLOWED_UPLOAD_TYPES: Readonly<Record<string, readonly string[]>> =
-  {
-    // Images
-    "image/jpeg": [".jpg", ".jpeg"],
-    "image/png": [".png"],
-    "image/webp": [".webp"],
-    "image/avif": [".avif"],
-    "image/gif": [".gif"],
-    "image/heic": [".heic", ".heif"],
-    "image/heif": [".heic", ".heif"],
-    "image/vnd.adobe.photoshop": [".psd"],
-    "application/octet-stream": [".psd"],
-    // Videos
-    "video/mp4": [".mp4"],
-    "video/quicktime": [".mov"],
-    "video/webm": [".webm"],
-  };
+  (() => {
+    const out: Record<string, string[]> = {};
+    for (const t of MEDIA_TYPES) {
+      const exts = [t.ext, ...(t.aliases ?? [])].map((e) => `.${e}`);
+      for (const mime of t.uploadMimes) {
+        out[mime] = [...new Set([...(out[mime] ?? []), ...exts])];
+      }
+    }
+    return out;
+  })();
+
+/**
+ * Content-type to serve a stored original with, keyed by file extension. Falls
+ * back to application/octet-stream for anything unknown (never a guessed type).
+ */
+export function contentTypeForExt(ext: string | undefined): string {
+  return (
+    (ext && CONTENT_TYPE_BY_EXT[ext.toLowerCase()]) || "application/octet-stream"
+  );
+}
+
+/**
+ * The distinct file extensions accepted at upload, for user-facing error
+ * messages. Derived from the same table so it can never list a stale set.
+ */
+export function allowedUploadExtensions(): string[] {
+  return [
+    ...new Set(MEDIA_TYPES.flatMap((t) => [t.ext, ...(t.aliases ?? [])])),
+  ].sort();
+}
 
 /**
  * Validates an upload's file type: the MIME type must be allowed and the

--- a/packages/core/src/utils/video/format.ts
+++ b/packages/core/src/utils/video/format.ts
@@ -1,3 +1,5 @@
+import { contentTypeForExt } from "../upload-validation";
+
 /**
  * Supported image formats for video thumbnails
  */
@@ -54,23 +56,10 @@ export const determineOutputFormat = (
 };
 
 /**
- * MIME content type for a resolved output format.
+ * MIME content type for a resolved output format or a stored original's
+ * extension. Backed by the single media-type table in upload-validation so the
+ * accepted-types whitelist and the content-type map cannot drift, and so audio /
+ * 3D originals get their real type instead of the old video/mp4 fallback.
  */
-const CONTENT_TYPE_BY_FORMAT: Readonly<Record<string, string>> = {
-  jpg: "image/jpeg",
-  png: "image/png",
-  webp: "image/webp",
-  avif: "image/avif",
-  gif: "image/gif",
-  mp4: "video/mp4",
-  webm: "video/webm",
-  mov: "video/quicktime",
-};
-
-export const contentTypeForFormat = (format: string): string => {
-  const normalized = normalizeFormat(format.toLowerCase());
-  if (CONTENT_TYPE_BY_FORMAT[normalized]) {
-    return CONTENT_TYPE_BY_FORMAT[normalized];
-  }
-  return IMAGE_FORMATS.has(normalized) ? `image/${normalized}` : "video/mp4";
-};
+export const contentTypeForFormat = (format: string): string =>
+  contentTypeForExt(normalizeFormat(format.toLowerCase()));


### PR DESCRIPTION
Adds support for storing and delivering audio (`wav`/`mp3`/`ogg`) and 3D (`glb`/`gltf`) files as untouched originals — no transform pipeline. Previously these uploads were rejected with `400 Invalid file type`.

This follows the shape we discussed: keep the first PR to storage + delivery only, no waveforms or 3D thumbnails, and lean on the existing "no params → original" behaviour so there are as few type-specific branches as possible.

## Changes

- **upload-validation:** unify the accepted-types whitelist and the extension→content-type map into one `MEDIA_TYPES` table so they can't drift. Add audio + 3D with the MIME variants browsers actually send (`audio/x-wav`, `application/ogg`, and `application/octet-stream` for `glb`, like `psd`).
- **transform:** a bare `/t/<path>` with no params now streams the original for any stored type, not just video. Images are unchanged (they always carry an auto-selected format at this point, so they keep optimizing).
- **format:** `contentTypeForFormat` is backed by the shared table and falls back to `application/octet-stream` instead of `video/mp4`, so `glb`/`wav` are labelled correctly.
- **upload route:** the "invalid file type" error now lists the accepted extensions from the table instead of a hard-coded image/video string that had drifted.

## Out of scope

Audio/3D transforms (waveforms, thumbnails, turntable), format conversion, and a config knob for allowed types. Left the bare `/t/<image>` → original + `f_auto` opt-in change alone so it doesn't collide with your planned image-path work.

## Testing

- Unit tests for the new types, content-type mapping, error-message list, and a bare audio/3D delivery that streams the original with its real content-type (`pnpm --filter @openinary/core test` — all green; `type-check` clean on core and api).
- Verified end-to-end against a local API + S3-compatible storage: `duck.glb` (120 KB), `helmet.glb` (3.7 MB), and a `.wav` upload and serve back via `/t/{path}` with the correct content-types (`model/gltf-binary`, `audio/wav`) and byte-identical round-trips.
