### PR TITLE
feat(ui): add border beam to the empty state upload button

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -55,6 +55,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tanstack/react-virtual": "^3.14.5",
+    "border-beam": "^1.3.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.24",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -24,6 +24,15 @@ export { RenameSection } from "./components/rename-section";
 export { ColumnCountSlider, MIN_COLUMNS, MAX_COLUMNS } from "./components/column-count-slider";
 export { VideoThumbnail } from "./components/video-thumbnail";
 export { UserAvatar } from "./components/user-avatar";
+// Re-exported as-is (no wrapper) so consumers keep border-beam's full prop
+// surface — colorVariant, strength, brightness, duration, etc.
+export {
+  BorderBeam,
+  type BorderBeamProps,
+  type BorderBeamSize,
+  type BorderBeamColorVariant,
+  type BorderBeamTheme,
+} from "border-beam";
 
 // Queue widgets
 export { JobStatusBadge, type JobStatus } from "./queue/job-status-badge";

--- a/packages/ui/src/media-grid.tsx
+++ b/packages/ui/src/media-grid.tsx
@@ -2,6 +2,8 @@
 
 import type React from "react";
 import { useState, useMemo, useEffect, useRef } from "react";
+import { BorderBeam, type BorderBeamProps } from "border-beam";
+import { useTheme } from "next-themes";
 import {
   FileImage,
   FileVideo,
@@ -157,6 +159,8 @@ export interface MediaGridProps {
   /** Current folder, e.g. "photos/2024". Root is `null`. Lifted to the caller since this package doesn't dictate a router. */
   folderPath?: string | null;
   onFolderPathChange?: (folderPath: string | null) => void;
+  /** Overrides for the beam around the empty-state upload button. Merged over the defaults, so any subset wins. Pass `active: false` to stop the animation. */
+  beamProps?: Omit<BorderBeamProps, "children">;
 }
 
 export function MediaGrid({
@@ -167,6 +171,7 @@ export function MediaGrid({
   scrollContainerRef,
   folderPath = null,
   onFolderPathChange,
+  beamProps,
 }: MediaGridProps) {
   const { apiBaseUrl, transformBaseUrl, fetch } = useOpeninary();
   const [hideThumbnails] = useHideThumbnails();
@@ -210,6 +215,10 @@ export function MediaGrid({
     onMove: (_destination: string) => {},
     onDelete: () => {},
   });
+
+  // BorderBeam picks its own colors per background; next-themes' class-based
+  // toggle isn't visible to its `theme="auto"` (prefers-color-scheme) mode.
+  const { resolvedTheme } = useTheme();
 
   // Dialog state for grid-level context menu
   const [gridUploadOpen, setGridUploadOpen] = useState(false);
@@ -442,7 +451,15 @@ export function MediaGrid({
           </EmptyHeader>
           <EmptyContent>
             <div className="flex gap-2">
-              <UploadButtonWithDialog />
+              <BorderBeam
+                size="pulse-outside"
+                colorVariant="colorful"
+                strength={0.7}
+                theme={resolvedTheme === "light" ? "light" : "dark"}
+                {...beamProps}
+              >
+                <UploadButtonWithDialog />
+              </BorderBeam>
               <Button variant="outline" asChild>
                 <a
                   href="https://docs.openinary.dev/"

--- a/packages/ui/src/media-grid.tsx
+++ b/packages/ui/src/media-grid.tsx
@@ -51,10 +51,7 @@ import { VideoThumbnail } from "./components/video-thumbnail";
 import { DefaultDialog } from "./components/default-dialog";
 import { RenameSection } from "./components/rename-section";
 import { DeleteConfirmDialog } from "./components/delete-confirm-dialog";
-import {
-  invalidateStorage,
-  useStorageLevel,
-} from "./hooks/use-storage-tree";
+import { invalidateStorage, useStorageLevel } from "./hooks/use-storage-tree";
 import { useHideThumbnails } from "./hooks/use-hide-thumbnails";
 import { useFolderSummaries } from "./hooks/use-folder-summaries";
 import { preloadMedia } from "./hooks/use-preload-media";
@@ -362,7 +359,9 @@ export function MediaGrid({
           .getVirtualItems()
           .flatMap((virtualRow) =>
             (folderRows[virtualRow.index] ?? [])
-              .filter((entry): entry is (typeof folders)[number] => entry !== null)
+              .filter(
+                (entry): entry is (typeof folders)[number] => entry !== null,
+              )
               .map((entry) => entry.path),
           )
       : folderListVirtualizer
@@ -504,7 +503,9 @@ export function MediaGrid({
   };
 
   const handleCopyUrl = (path: string, id?: string) => {
-    navigator.clipboard.writeText(toAbsoluteUrl(`${transformBaseUrl}/t/${path}`));
+    navigator.clipboard.writeText(
+      toAbsoluteUrl(`${transformBaseUrl}/t/${path}`),
+    );
     toast.success("URL copied to clipboard");
     if (id) {
       setCopiedId(id);
@@ -906,15 +907,11 @@ export function MediaGrid({
           <Move className="h-4 w-4" />
           Move selection
         </ContextMenuSubTrigger>
-        <ContextMenuSubContent
-          className="w-48 max-h-[400px] overflow-y-auto"
-        >
+        <ContextMenuSubContent className="w-48 max-h-[400px] overflow-y-auto">
           <MoveToNavigator
             ItemComponent={ContextMenuItem}
             currentDir={currentDir}
-            onSelect={(destination) =>
-              setBulkMoveDestination({ destination })
-            }
+            onSelect={(destination) => setBulkMoveDestination({ destination })}
           />
         </ContextMenuSubContent>
       </ContextMenuSub>
@@ -1082,236 +1079,271 @@ export function MediaGrid({
         <ContextMenuTrigger asChild>
           <div className="space-y-4">
             {view === "grid" && (
-            <div
-              ref={setFoldersEl}
-              style={{
-                height: folderVirtualizer.getTotalSize(),
-                position: "relative",
-              }}
-            >
-              {folderVirtualizer.getVirtualItems().map((virtualRow) => (
-                <div
-                  key={virtualRow.key}
-                  data-index={virtualRow.index}
-                  ref={folderVirtualizer.measureElement}
-                  className="absolute top-0 left-0 w-full pb-4"
-                  style={{
-                    transform: `translateY(${virtualRow.start - folderVirtualizer.options.scrollMargin}px)`,
-                  }}
-                >
-                  <div className="flex flex-wrap gap-4">
-              {folderRows[virtualRow.index].map((entry) => {
-                if (entry === null) {
-                  return (
-                    <CreateFolderButtonWithDialog
-                      key="__new-folder__"
-                      uploadToFolder={folderPath || undefined}
-                      trigger={
-                        <div className="group relative w-[190px] h-[180px] rounded-lg border border-dashed border-border cursor-pointer transition-all hover:border-primary/40 hover:bg-muted/30 flex flex-col items-center justify-center gap-2">
-                          <Plus
-                            className="h-6 w-6 text-muted-foreground"
-                            strokeWidth={1.5}
-                          />
-                          <p className="text-sm text-muted-foreground">
-                            New folder
-                          </p>
-                        </div>
-                      }
-                    />
-                  );
-                }
-                const folder = entry;
-                const summary = folderSummaries[folder.path];
-                const itemCountLabel = !summary
-                  ? "…"
-                  : summary.truncated
-                    ? `${summary.itemCount}+`
-                    : `${summary.itemCount}`;
-                const previewItems =
-                  hideThumbnails || !summary ? [] : summary.previewItems;
-                const renderPreview = (
-                  item: { path: string; type: "image" | "video" },
-                  size: "square" | "tall" | "large",
-                ) =>
-                  item.type === "video" ? (
-                    <VideoThumbnail
-                      src={getFolderThumbnailUrl(transformBaseUrl, item, size)}
-                      alt=""
-                      className="w-full h-full object-cover"
-                      loading="lazy"
-                    />
-                  ) : (
-                    <img
-                      src={getFolderThumbnailUrl(transformBaseUrl, item, size)}
-                      alt=""
-                      className="w-full h-full object-cover"
-                      loading="lazy"
-                    />
-                  );
-                return (
-                  <ContextMenu
-                    key={folder.path}
-                    onOpenChange={(open) =>
-                      setOpenMenuId(open ? folder.path : null)
-                    }
+              <div
+                ref={setFoldersEl}
+                style={{
+                  height: folderVirtualizer.getTotalSize(),
+                  position: "relative",
+                }}
+              >
+                {folderVirtualizer.getVirtualItems().map((virtualRow) => (
+                  <div
+                    key={virtualRow.key}
+                    data-index={virtualRow.index}
+                    ref={folderVirtualizer.measureElement}
+                    className="absolute top-0 left-0 w-full pb-4"
+                    style={{
+                      transform: `translateY(${virtualRow.start - folderVirtualizer.options.scrollMargin}px)`,
+                    }}
                   >
-                    <ContextMenuTrigger asChild>
-                      <div
-                        className={cn(
-                          "group relative w-[190px] h-[180px] rounded-lg overflow-hidden border border-border bg-muted/30 cursor-pointer transition-all hover:border-primary/30 hover:shadow-md data-[state=open]:border-primary/30 data-[state=open]:shadow-md",
-                          isSelected(folder.path) &&
-                            "ring-2 ring-primary border-primary",
-                        )}
-                        onClick={() => handleFolderClick(folder.path)}
-                        onContextMenu={(e) => e.stopPropagation()}
-                      >
-                        <div
-                          className={cn(
-                            "absolute top-2 left-2 z-10 transition-opacity",
-                            selectionMode || isSelected(folder.path)
-                              ? "opacity-100"
-                              : "opacity-0 group-hover:opacity-100 group-data-[state=open]:opacity-100",
-                          )}
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <Checkbox
-                            checked={isSelected(folder.path)}
-                            onCheckedChange={() =>
-                              toggleSelection(folder.path, {
-                                path: folder.path,
-                                name: folder.name,
-                                kind: "folder",
-                              })
-                            }
-                          />
-                        </div>
-                        <div className="relative w-full h-full">
-                          {previewItems.length === 4 ? (
-                            <div className="grid grid-cols-2 gap-0.5 w-full h-full">
-                              {previewItems.map((item, i) => (
-                                <div key={i} className="overflow-hidden">
-                                  {renderPreview(item, "square")}
+                    <div className="flex flex-wrap gap-4">
+                      {folderRows[virtualRow.index].map((entry) => {
+                        if (entry === null) {
+                          return (
+                            <CreateFolderButtonWithDialog
+                              key="__new-folder__"
+                              uploadToFolder={folderPath || undefined}
+                              trigger={
+                                <div className="group relative w-[190px] h-[180px] rounded-lg border border-dashed border-border cursor-pointer transition-all hover:border-primary/40 hover:bg-muted/30 flex flex-col items-center justify-center gap-2">
+                                  <Plus
+                                    className="h-6 w-6 text-muted-foreground"
+                                    strokeWidth={1.5}
+                                  />
+                                  <p className="text-sm text-muted-foreground">
+                                    New folder
+                                  </p>
                                 </div>
-                              ))}
-                            </div>
-                          ) : previewItems.length === 3 ? (
-                            <div className="grid grid-cols-2 gap-0.5 w-full h-full">
-                              <div className="overflow-hidden row-span-2">
-                                {renderPreview(previewItems[0], "tall")}
-                              </div>
-                              {previewItems.slice(1).map((item, i) => (
-                                <div key={i} className="overflow-hidden">
-                                  {renderPreview(item, "square")}
-                                </div>
-                              ))}
-                            </div>
-                          ) : previewItems.length === 2 ? (
-                            <div className="grid grid-cols-2 gap-0.5 w-full h-full">
-                              {previewItems.map((item, i) => (
-                                <div key={i} className="overflow-hidden">
-                                  {renderPreview(item, "tall")}
-                                </div>
-                              ))}
-                            </div>
-                          ) : previewItems.length === 1 ? (
-                            renderPreview(previewItems[0], "large")
+                              }
+                            />
+                          );
+                        }
+                        const folder = entry;
+                        const summary = folderSummaries[folder.path];
+                        const itemCountLabel = !summary
+                          ? "…"
+                          : summary.truncated
+                            ? `${summary.itemCount}+`
+                            : `${summary.itemCount}`;
+                        const previewItems =
+                          hideThumbnails || !summary
+                            ? []
+                            : summary.previewItems;
+                        const renderPreview = (
+                          item: { path: string; type: "image" | "video" },
+                          size: "square" | "tall" | "large",
+                        ) =>
+                          item.type === "video" ? (
+                            <VideoThumbnail
+                              src={getFolderThumbnailUrl(
+                                transformBaseUrl,
+                                item,
+                                size,
+                              )}
+                              alt=""
+                              className="w-full h-full object-cover"
+                              loading="lazy"
+                            />
                           ) : (
-                            <div className="w-full h-full flex items-center justify-center bg-muted/30">
-                              <Folder
-                                className="h-8 w-8 text-muted-foreground"
-                                strokeWidth={1.5}
-                              />
-                            </div>
-                          )}
-                        </div>
-                        <div
-                          className={cn(
-                            "absolute inset-x-0 bottom-0 max-w-full p-3 text-left",
-                            hideThumbnails
-                              ? ""
-                              : "bg-gradient-to-t from-black/80 via-black/40 to-transparent",
-                          )}
-                        >
-                          <p
-                            className={cn(
-                              "text-sm font-medium truncate",
-                              hideThumbnails ? "text-foreground" : "text-white",
-                            )}
+                            <img
+                              src={getFolderThumbnailUrl(
+                                transformBaseUrl,
+                                item,
+                                size,
+                              )}
+                              alt=""
+                              className="w-full h-full object-cover"
+                              loading="lazy"
+                            />
+                          );
+                        return (
+                          <ContextMenu
+                            key={folder.path}
+                            onOpenChange={(open) =>
+                              setOpenMenuId(open ? folder.path : null)
+                            }
                           >
-                            {folder.name}
-                          </p>
-                          <p
-                            className={cn(
-                              "text-xs",
-                              hideThumbnails
-                                ? "text-muted-foreground"
-                                : "text-white/70",
+                            <ContextMenuTrigger asChild>
+                              <div
+                                className={cn(
+                                  "group relative w-[190px] h-[180px] rounded-lg overflow-hidden border border-border bg-muted/30 cursor-pointer transition-all hover:border-primary/30 hover:shadow-md data-[state=open]:border-primary/30 data-[state=open]:shadow-md",
+                                  isSelected(folder.path) &&
+                                    "ring-2 ring-primary border-primary",
+                                )}
+                                onClick={() => handleFolderClick(folder.path)}
+                                onContextMenu={(e) => e.stopPropagation()}
+                              >
+                                <div
+                                  className={cn(
+                                    "absolute top-2 left-2 z-10 transition-opacity",
+                                    selectionMode || isSelected(folder.path)
+                                      ? "opacity-100"
+                                      : "opacity-0 group-hover:opacity-100 group-data-[state=open]:opacity-100",
+                                  )}
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  <Checkbox
+                                    checked={isSelected(folder.path)}
+                                    onCheckedChange={() =>
+                                      toggleSelection(folder.path, {
+                                        path: folder.path,
+                                        name: folder.name,
+                                        kind: "folder",
+                                      })
+                                    }
+                                  />
+                                </div>
+                                <div className="relative w-full h-full">
+                                  {previewItems.length === 4 ? (
+                                    <div className="grid grid-cols-2 gap-0.5 w-full h-full">
+                                      {previewItems.map((item, i) => (
+                                        <div
+                                          key={i}
+                                          className="overflow-hidden"
+                                        >
+                                          {renderPreview(item, "square")}
+                                        </div>
+                                      ))}
+                                    </div>
+                                  ) : previewItems.length === 3 ? (
+                                    <div className="grid grid-cols-2 gap-0.5 w-full h-full">
+                                      <div className="overflow-hidden row-span-2">
+                                        {renderPreview(previewItems[0], "tall")}
+                                      </div>
+                                      {previewItems.slice(1).map((item, i) => (
+                                        <div
+                                          key={i}
+                                          className="overflow-hidden"
+                                        >
+                                          {renderPreview(item, "square")}
+                                        </div>
+                                      ))}
+                                    </div>
+                                  ) : previewItems.length === 2 ? (
+                                    <div className="grid grid-cols-2 gap-0.5 w-full h-full">
+                                      {previewItems.map((item, i) => (
+                                        <div
+                                          key={i}
+                                          className="overflow-hidden"
+                                        >
+                                          {renderPreview(item, "tall")}
+                                        </div>
+                                      ))}
+                                    </div>
+                                  ) : previewItems.length === 1 ? (
+                                    renderPreview(previewItems[0], "large")
+                                  ) : (
+                                    <div className="w-full h-full flex items-center justify-center bg-muted/30">
+                                      <Folder
+                                        className="h-8 w-8 text-muted-foreground"
+                                        strokeWidth={1.5}
+                                      />
+                                    </div>
+                                  )}
+                                </div>
+                                <div
+                                  className={cn(
+                                    "absolute inset-x-0 bottom-0 max-w-full p-3 text-left",
+                                    hideThumbnails
+                                      ? ""
+                                      : "bg-gradient-to-t from-black/80 via-black/40 to-transparent",
+                                  )}
+                                >
+                                  <p
+                                    className={cn(
+                                      "text-sm font-medium truncate",
+                                      hideThumbnails
+                                        ? "text-foreground"
+                                        : "text-white",
+                                    )}
+                                  >
+                                    {folder.name}
+                                  </p>
+                                  <p
+                                    className={cn(
+                                      "text-xs",
+                                      hideThumbnails
+                                        ? "text-muted-foreground"
+                                        : "text-white/70",
+                                    )}
+                                  >
+                                    {itemCountLabel}{" "}
+                                    {summary &&
+                                    summary.itemCount === 1 &&
+                                    !summary.truncated
+                                      ? "item"
+                                      : "items"}
+                                  </p>
+                                </div>
+                              </div>
+                            </ContextMenuTrigger>
+                            {selectionMode ? (
+                              openMenuId === folder.path ? (
+                                renderBulkContextMenuContent()
+                              ) : null
+                            ) : (
+                              <ContextMenuContent>
+                                <ContextMenuItem
+                                  onClick={(e: React.MouseEvent) => {
+                                    e.stopPropagation();
+                                    const path = folder.path;
+                                    setTimeout(
+                                      () => setFolderUploadTarget(path),
+                                      0,
+                                    );
+                                  }}
+                                >
+                                  <Upload className="h-4 w-4" />
+                                  Upload to folder
+                                </ContextMenuItem>
+                                <ContextMenuItem
+                                  onClick={(e: React.MouseEvent) => {
+                                    e.stopPropagation();
+                                    const target = folder;
+                                    setTimeout(
+                                      () => setRenameFolderTarget(target),
+                                      0,
+                                    );
+                                  }}
+                                >
+                                  <Pencil className="h-4 w-4" />
+                                  Rename
+                                </ContextMenuItem>
+                                <ContextMenuItem
+                                  onClick={(e: React.MouseEvent) => {
+                                    e.stopPropagation();
+                                    handleDownloadFolder(
+                                      folder.path,
+                                      folder.name,
+                                    );
+                                  }}
+                                >
+                                  <Download className="h-4 w-4" />
+                                  Download folder
+                                </ContextMenuItem>
+                                <ContextMenuSeparator />
+                                <ContextMenuItem
+                                  onClick={(e: React.MouseEvent) => {
+                                    e.stopPropagation();
+                                    const path = folder.path;
+                                    setTimeout(
+                                      () => setDeleteFolderTarget(path),
+                                      0,
+                                    );
+                                  }}
+                                  variant="destructive"
+                                >
+                                  <Trash2 className="h-4 w-4" />
+                                  Delete folder
+                                </ContextMenuItem>
+                              </ContextMenuContent>
                             )}
-                          >
-                            {itemCountLabel}{" "}
-                            {summary && summary.itemCount === 1 && !summary.truncated
-                              ? "item"
-                              : "items"}
-                          </p>
-                        </div>
-                      </div>
-                    </ContextMenuTrigger>
-                    {selectionMode ? (
-                      openMenuId === folder.path ? (
-                        renderBulkContextMenuContent()
-                      ) : null
-                    ) : (
-                      <ContextMenuContent>
-                        <ContextMenuItem
-                          onClick={(e: React.MouseEvent) => {
-                            e.stopPropagation();
-                            const path = folder.path;
-                            setTimeout(() => setFolderUploadTarget(path), 0);
-                          }}
-                        >
-                          <Upload className="h-4 w-4" />
-                          Upload to folder
-                        </ContextMenuItem>
-                        <ContextMenuItem
-                          onClick={(e: React.MouseEvent) => {
-                            e.stopPropagation();
-                            const target = folder;
-                            setTimeout(() => setRenameFolderTarget(target), 0);
-                          }}
-                        >
-                          <Pencil className="h-4 w-4" />
-                          Rename
-                        </ContextMenuItem>
-                        <ContextMenuItem
-                          onClick={(e: React.MouseEvent) => {
-                            e.stopPropagation();
-                            handleDownloadFolder(folder.path, folder.name);
-                          }}
-                        >
-                          <Download className="h-4 w-4" />
-                          Download folder
-                        </ContextMenuItem>
-                        <ContextMenuSeparator />
-                        <ContextMenuItem
-                          onClick={(e: React.MouseEvent) => {
-                            e.stopPropagation();
-                            const path = folder.path;
-                            setTimeout(() => setDeleteFolderTarget(path), 0);
-                          }}
-                          variant="destructive"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                          Delete folder
-                        </ContextMenuItem>
-                      </ContextMenuContent>
-                    )}
-                  </ContextMenu>
-                );
-              })}
+                          </ContextMenu>
+                        );
+                      })}
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
             )}
 
             {view === "list" && (
@@ -1583,164 +1615,171 @@ export function MediaGrid({
                     >
                       <div className="grid gap-4" style={gridStyle}>
                         {row.map((media) => {
-                  // For images: resize and optimize
-                  // For videos: extract thumbnail at 1 second as jpg image with crop mode to avoid stretching
-                  const thumbnailUrl =
-                    media.type === "image"
-                      ? `${transformBaseUrl}/t/w_500,h_500,q_80/${media.path}`
-                      : `${transformBaseUrl}/t/t_true,tt_5,f_webp,w_500,h_500,c_fill,q_80/${media.path}`;
-                  const isHovered = hoveredId === media.id;
+                          // For images: resize and optimize
+                          // For videos: extract thumbnail at 1 second as jpg image with crop mode to avoid stretching
+                          const thumbnailUrl =
+                            media.type === "image"
+                              ? `${transformBaseUrl}/t/w_500,h_500,q_80/${media.path}`
+                              : `${transformBaseUrl}/t/t_true,tt_5,f_webp,w_500,h_500,c_fill,q_80/${media.path}`;
+                          const isHovered = hoveredId === media.id;
 
-                  return (
-                    <ContextMenu
-                      key={media.id}
-                      onOpenChange={(open) => {
-                        setOpenMenuId(open ? media.id : null);
-                        if (open) setHoveredId(media.id);
-                      }}
-                    >
-                      <ContextMenuTrigger asChild>
-                        <div
-                          className={cn(
-                            "group relative aspect-square rounded-lg overflow-hidden border border-border bg-muted/50 cursor-pointer transition-all hover:border-primary/30 hover:shadow-md data-[state=open]:border-primary/30 data-[state=open]:shadow-md [content-visibility:auto] [contain-intrinsic-size:auto_300px]",
-                            isSelected(media.id) &&
-                              "ring-2 ring-primary border-primary",
-                          )}
-                          onClick={() => onMediaSelect(media)}
-                          onContextMenu={(e) => e.stopPropagation()}
-                          onMouseEnter={() => {
-                            setHoveredId(media.id);
-                            handleMediaHover(media);
-                          }}
-                          onMouseLeave={() => setHoveredId(null)}
-                        >
-                          <div
-                            className={cn(
-                              "absolute top-2 left-2 z-10 transition-opacity",
-                              selectionMode || isSelected(media.id)
-                                ? "opacity-100"
-                                : "opacity-0 group-hover:opacity-100 group-data-[state=open]:opacity-100",
-                            )}
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            <Checkbox
-                              checked={isSelected(media.id)}
-                              onCheckedChange={() =>
-                                toggleSelection(media.id, {
-                                  path: media.path,
-                                  name: media.name,
-                                  kind: "file",
-                                })
-                              }
-                            />
-                          </div>
-                          {hideThumbnails ? (
-                            <FileTypeIcon type={media.type} />
-                          ) : media.type === "image" ? (
-                            <img
-                              src={thumbnailUrl}
-                              alt={media.name}
-                              className="w-full h-full object-cover transition-transform group-hover:scale-105 group-data-[state=open]:scale-105"
-                              loading="lazy"
-                            />
-                          ) : (
-                            <VideoThumbnail
-                              src={thumbnailUrl}
-                              alt={media.name}
-                              className="transition-transform group-hover:scale-105 group-data-[state=open]:scale-105"
-                              loading="lazy"
-                            />
-                          )}
-                          <div
-                            className={cn(
-                              "absolute inset-x-0 bottom-0 p-2 transition-opacity",
-                              hideThumbnails
-                                ? ""
-                                : "bg-gradient-to-t from-black/80 via-black/40 to-transparent",
-                              isHovered ? "opacity-100" : "opacity-0",
-                              "group-data-[state=open]:opacity-100",
-                            )}
-                          >
-                            <p
-                              className={cn(
-                                "text-xs font-medium truncate",
-                                hideThumbnails
-                                  ? "text-foreground"
-                                  : "text-white",
+                          return (
+                            <ContextMenu
+                              key={media.id}
+                              onOpenChange={(open) => {
+                                setOpenMenuId(open ? media.id : null);
+                                if (open) setHoveredId(media.id);
+                              }}
+                            >
+                              <ContextMenuTrigger asChild>
+                                <div
+                                  className={cn(
+                                    "group relative aspect-square rounded-lg overflow-hidden border border-border bg-muted/50 cursor-pointer transition-all hover:border-primary/30 hover:shadow-md data-[state=open]:border-primary/30 data-[state=open]:shadow-md [content-visibility:auto] [contain-intrinsic-size:auto_300px]",
+                                    isSelected(media.id) &&
+                                      "ring-2 ring-primary border-primary",
+                                  )}
+                                  onClick={() => onMediaSelect(media)}
+                                  onContextMenu={(e) => e.stopPropagation()}
+                                  onMouseEnter={() => {
+                                    setHoveredId(media.id);
+                                    handleMediaHover(media);
+                                  }}
+                                  onMouseLeave={() => setHoveredId(null)}
+                                >
+                                  <div
+                                    className={cn(
+                                      "absolute top-2 left-2 z-10 transition-opacity",
+                                      selectionMode || isSelected(media.id)
+                                        ? "opacity-100"
+                                        : "opacity-0 group-hover:opacity-100 group-data-[state=open]:opacity-100",
+                                    )}
+                                    onClick={(e) => e.stopPropagation()}
+                                  >
+                                    <Checkbox
+                                      checked={isSelected(media.id)}
+                                      onCheckedChange={() =>
+                                        toggleSelection(media.id, {
+                                          path: media.path,
+                                          name: media.name,
+                                          kind: "file",
+                                        })
+                                      }
+                                    />
+                                  </div>
+                                  {hideThumbnails ? (
+                                    <FileTypeIcon type={media.type} />
+                                  ) : media.type === "image" ? (
+                                    <img
+                                      src={thumbnailUrl}
+                                      alt={media.name}
+                                      className="w-full h-full object-cover transition-transform group-hover:scale-105 group-data-[state=open]:scale-105"
+                                      loading="lazy"
+                                    />
+                                  ) : (
+                                    <VideoThumbnail
+                                      src={thumbnailUrl}
+                                      alt={media.name}
+                                      className="transition-transform group-hover:scale-105 group-data-[state=open]:scale-105"
+                                      loading="lazy"
+                                    />
+                                  )}
+                                  <div
+                                    className={cn(
+                                      "absolute inset-x-0 bottom-0 p-2 transition-opacity",
+                                      hideThumbnails
+                                        ? ""
+                                        : "bg-gradient-to-t from-black/80 via-black/40 to-transparent",
+                                      isHovered ? "opacity-100" : "opacity-0",
+                                      "group-data-[state=open]:opacity-100",
+                                    )}
+                                  >
+                                    <p
+                                      className={cn(
+                                        "text-xs font-medium truncate",
+                                        hideThumbnails
+                                          ? "text-foreground"
+                                          : "text-white",
+                                      )}
+                                    >
+                                      {media.name}
+                                    </p>
+                                  </div>
+                                </div>
+                              </ContextMenuTrigger>
+                              {!isHovered &&
+                              openMenuId !== media.id ? null : selectionMode ? (
+                                renderBulkContextMenuContent()
+                              ) : (
+                                <ContextMenuContent className="w-64">
+                                  <ContextMenuItem
+                                    onClick={() => onMediaSelect(media)}
+                                  >
+                                    <File className="h-4 w-4" />
+                                    Open
+                                  </ContextMenuItem>
+                                  <ContextMenuItem
+                                    onClick={() =>
+                                      setTimeout(
+                                        () => setRenameTarget(media),
+                                        0,
+                                      )
+                                    }
+                                  >
+                                    <Pencil className="h-4 w-4" />
+                                    Rename
+                                  </ContextMenuItem>
+                                  <ContextMenuItem
+                                    onClick={() => handleCopyMedia(media.path)}
+                                  >
+                                    <Copy className="h-4 w-4" />
+                                    Make a copy
+                                  </ContextMenuItem>
+                                  <ContextMenuSub>
+                                    <ContextMenuSubTrigger>
+                                      <Move className="h-4 w-4" />
+                                      Move to
+                                    </ContextMenuSubTrigger>
+                                    <ContextMenuSubContent className="w-48 max-h-[400px] overflow-y-auto">
+                                      <MoveToNavigator
+                                        ItemComponent={ContextMenuItem}
+                                        currentDir={currentDir}
+                                        onSelect={(path) =>
+                                          setMoveMediaTarget({
+                                            media,
+                                            destination: path,
+                                          })
+                                        }
+                                      />
+                                    </ContextMenuSubContent>
+                                  </ContextMenuSub>
+                                  <ContextMenuItem
+                                    onClick={() =>
+                                      handleDownload(media.path, media.name)
+                                    }
+                                  >
+                                    <Download className="h-4 w-4" />
+                                    Download
+                                    <ContextMenuShortcut>
+                                      {mac ? "⇧⌘D" : "Ctrl Shift D"}
+                                    </ContextMenuShortcut>
+                                  </ContextMenuItem>
+                                  <ContextMenuSeparator />
+                                  <ContextMenuItem
+                                    onClick={() =>
+                                      setTimeout(
+                                        () => setDeleteMediaTarget(media),
+                                        0,
+                                      )
+                                    }
+                                    variant="destructive"
+                                  >
+                                    <Trash2 className="h-4 w-4" />
+                                    Delete
+                                  </ContextMenuItem>
+                                </ContextMenuContent>
                               )}
-                            >
-                              {media.name}
-                            </p>
-                          </div>
-                        </div>
-                      </ContextMenuTrigger>
-                      {!isHovered && openMenuId !== media.id ? null : selectionMode ? (
-                        renderBulkContextMenuContent()
-                      ) : (
-                        <ContextMenuContent className="w-64">
-                          <ContextMenuItem onClick={() => onMediaSelect(media)}>
-                            <File className="h-4 w-4" />
-                            Open
-                          </ContextMenuItem>
-                          <ContextMenuItem
-                            onClick={() =>
-                              setTimeout(() => setRenameTarget(media), 0)
-                            }
-                          >
-                            <Pencil className="h-4 w-4" />
-                            Rename
-                          </ContextMenuItem>
-                          <ContextMenuItem
-                            onClick={() => handleCopyMedia(media.path)}
-                          >
-                            <Copy className="h-4 w-4" />
-                            Make a copy
-                          </ContextMenuItem>
-                          <ContextMenuSub>
-                            <ContextMenuSubTrigger>
-                              <Move className="h-4 w-4" />
-                              Move to
-                            </ContextMenuSubTrigger>
-                            <ContextMenuSubContent
-                              className="w-48 max-h-[400px] overflow-y-auto"
-                            >
-                              <MoveToNavigator
-                                ItemComponent={ContextMenuItem}
-                                currentDir={currentDir}
-                                onSelect={(path) =>
-                                  setMoveMediaTarget({
-                                    media,
-                                    destination: path,
-                                  })
-                                }
-                              />
-                            </ContextMenuSubContent>
-                          </ContextMenuSub>
-                          <ContextMenuItem
-                            onClick={() =>
-                              handleDownload(media.path, media.name)
-                            }
-                          >
-                            <Download className="h-4 w-4" />
-                            Download
-                            <ContextMenuShortcut>
-                              {mac ? "⇧⌘D" : "Ctrl Shift D"}
-                            </ContextMenuShortcut>
-                          </ContextMenuItem>
-                          <ContextMenuSeparator />
-                          <ContextMenuItem
-                            onClick={() =>
-                              setTimeout(() => setDeleteMediaTarget(media), 0)
-                            }
-                            variant="destructive"
-                          >
-                            <Trash2 className="h-4 w-4" />
-                            Delete
-                          </ContextMenuItem>
-                        </ContextMenuContent>
-                      )}
-                    </ContextMenu>
-                  );
+                            </ContextMenu>
+                          );
                         })}
                       </div>
                     </div>
@@ -1779,224 +1818,225 @@ export function MediaGrid({
                         transform: `translateY(${virtualRow.start - listVirtualizer.options.scrollMargin}px)`,
                       }}
                     >
-                    <ContextMenu
-                      onOpenChange={(open) => {
-                        setOpenMenuId(open ? media.id : null);
-                        if (open) setHoveredId(media.id);
-                      }}
-                    >
-                      <ContextMenuTrigger asChild>
-                        <div
-                          className={cn(
-                            "group flex items-center gap-4 px-3 py-2 border-b border-border cursor-pointer transition-colors hover:bg-muted/50 data-[state=open]:bg-muted/50 [content-visibility:auto] [contain-intrinsic-size:auto_41px]",
-                            isSelected(media.id) && "bg-muted/40",
-                          )}
-                          onClick={() => onMediaSelect(media)}
-                          onContextMenu={(e) => e.stopPropagation()}
-                          onMouseEnter={() => {
-                            setHoveredId(media.id);
-                            handleMediaHover(media);
-                          }}
-                          onMouseLeave={() => setHoveredId(null)}
-                        >
+                      <ContextMenu
+                        onOpenChange={(open) => {
+                          setOpenMenuId(open ? media.id : null);
+                          if (open) setHoveredId(media.id);
+                        }}
+                      >
+                        <ContextMenuTrigger asChild>
                           <div
-                            className="relative h-6 w-6 shrink-0 overflow-hidden rounded bg-muted/50 cursor-pointer"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              toggleSelection(media.id, {
-                                path: media.path,
-                                name: media.name,
-                                kind: "file",
-                              });
-                            }}
-                          >
-                            {hideThumbnails ? (
-                              <FileTypeIcon type={media.type} />
-                            ) : media.type === "image" ? (
-                              <img
-                                src={thumbnailUrl}
-                                alt={media.name}
-                                className="h-full w-full object-cover"
-                                loading="lazy"
-                              />
-                            ) : (
-                              <VideoThumbnail
-                                src={thumbnailUrl}
-                                alt={media.name}
-                                className="h-full w-full object-cover"
-                                loading="lazy"
-                              />
+                            className={cn(
+                              "group flex items-center gap-4 px-3 py-2 border-b border-border cursor-pointer transition-colors hover:bg-muted/50 data-[state=open]:bg-muted/50 [content-visibility:auto] [contain-intrinsic-size:auto_41px]",
+                              isSelected(media.id) && "bg-muted/40",
                             )}
+                            onClick={() => onMediaSelect(media)}
+                            onContextMenu={(e) => e.stopPropagation()}
+                            onMouseEnter={() => {
+                              setHoveredId(media.id);
+                              handleMediaHover(media);
+                            }}
+                            onMouseLeave={() => setHoveredId(null)}
+                          >
                             <div
-                              className={cn(
-                                "absolute inset-0 flex items-center justify-center bg-black/50 transition-opacity",
-                                selectionMode || isSelected(media.id)
-                                  ? "opacity-100"
-                                  : "opacity-0 group-hover:opacity-100 group-data-[state=open]:opacity-100",
-                              )}
+                              className="relative h-6 w-6 shrink-0 overflow-hidden rounded bg-muted/50 cursor-pointer"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                toggleSelection(media.id, {
+                                  path: media.path,
+                                  name: media.name,
+                                  kind: "file",
+                                });
+                              }}
                             >
-                              <Checkbox
-                                checked={isSelected(media.id)}
-                                onCheckedChange={() =>
-                                  toggleSelection(media.id, {
-                                    path: media.path,
-                                    name: media.name,
-                                    kind: "file",
-                                  })
-                                }
-                                onClick={(e) => e.stopPropagation()}
-                                className="size-4"
-                              />
+                              {hideThumbnails ? (
+                                <FileTypeIcon type={media.type} />
+                              ) : media.type === "image" ? (
+                                <img
+                                  src={thumbnailUrl}
+                                  alt={media.name}
+                                  className="h-full w-full object-cover"
+                                  loading="lazy"
+                                />
+                              ) : (
+                                <VideoThumbnail
+                                  src={thumbnailUrl}
+                                  alt={media.name}
+                                  className="h-full w-full object-cover"
+                                  loading="lazy"
+                                />
+                              )}
+                              <div
+                                className={cn(
+                                  "absolute inset-0 flex items-center justify-center bg-black/50 transition-opacity",
+                                  selectionMode || isSelected(media.id)
+                                    ? "opacity-100"
+                                    : "opacity-0 group-hover:opacity-100 group-data-[state=open]:opacity-100",
+                                )}
+                              >
+                                <Checkbox
+                                  checked={isSelected(media.id)}
+                                  onCheckedChange={() =>
+                                    toggleSelection(media.id, {
+                                      path: media.path,
+                                      name: media.name,
+                                      kind: "file",
+                                    })
+                                  }
+                                  onClick={(e) => e.stopPropagation()}
+                                  className="size-4"
+                                />
+                              </div>
+                            </div>
+                            <p
+                              className="min-w-0 flex-1 truncate text-sm"
+                              title={media.name}
+                            >
+                              {media.name}
+                            </p>
+                            <span className="w-32 shrink-0 text-right text-xs text-muted-foreground">
+                              {getMimeType(media.name)}
+                            </span>
+                            <span className="w-24 shrink-0 text-right text-xs text-muted-foreground">
+                              {formatListSize(media.size)}
+                            </span>
+                            <div className="flex w-28 shrink-0 items-center justify-end">
+                              {isHovered ? (
+                                <div className="flex items-center gap-3">
+                                  <button
+                                    type="button"
+                                    className="relative h-4 w-4 cursor-pointer text-muted-foreground hover:text-foreground disabled:cursor-default"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleCopyUrl(media.path, media.id);
+                                    }}
+                                    disabled={copiedId === media.id}
+                                    aria-label="Copy URL"
+                                  >
+                                    <Check
+                                      className={cn(
+                                        "absolute inset-0 h-4 w-4 stroke-emerald-500 transition-all",
+                                        copiedId === media.id
+                                          ? "scale-100 opacity-100 blur-0"
+                                          : "scale-0 opacity-0 blur-sm",
+                                      )}
+                                    />
+                                    <Link2
+                                      className={cn(
+                                        "absolute inset-0 h-4 w-4 transition-all",
+                                        copiedId === media.id
+                                          ? "scale-0 opacity-0 blur-sm"
+                                          : "scale-100 opacity-100 blur-0",
+                                      )}
+                                    />
+                                  </button>
+                                  <button
+                                    type="button"
+                                    className="cursor-pointer text-muted-foreground hover:text-foreground"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleDownload(media.path, media.name);
+                                    }}
+                                    aria-label="Download"
+                                  >
+                                    <Download className="h-4 w-4" />
+                                  </button>
+                                  <button
+                                    type="button"
+                                    className="cursor-pointer text-muted-foreground hover:text-destructive"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      setTimeout(
+                                        () => setDeleteMediaTarget(media),
+                                        0,
+                                      );
+                                    }}
+                                    aria-label="Delete"
+                                  >
+                                    <Trash2 className="h-4 w-4" />
+                                  </button>
+                                </div>
+                              ) : (
+                                <span className="text-xs text-muted-foreground">
+                                  {formatListDate(media.mtime)}
+                                </span>
+                              )}
                             </div>
                           </div>
-                          <p
-                            className="min-w-0 flex-1 truncate text-sm"
-                            title={media.name}
-                          >
-                            {media.name}
-                          </p>
-                          <span className="w-32 shrink-0 text-right text-xs text-muted-foreground">
-                            {getMimeType(media.name)}
-                          </span>
-                          <span className="w-24 shrink-0 text-right text-xs text-muted-foreground">
-                            {formatListSize(media.size)}
-                          </span>
-                          <div className="flex w-28 shrink-0 items-center justify-end">
-                            {isHovered ? (
-                              <div className="flex items-center gap-3">
-                                <button
-                                  type="button"
-                                  className="relative h-4 w-4 cursor-pointer text-muted-foreground hover:text-foreground disabled:cursor-default"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    handleCopyUrl(media.path, media.id);
-                                  }}
-                                  disabled={copiedId === media.id}
-                                  aria-label="Copy URL"
-                                >
-                                  <Check
-                                    className={cn(
-                                      "absolute inset-0 h-4 w-4 stroke-emerald-500 transition-all",
-                                      copiedId === media.id
-                                        ? "scale-100 opacity-100 blur-0"
-                                        : "scale-0 opacity-0 blur-sm",
-                                    )}
-                                  />
-                                  <Link2
-                                    className={cn(
-                                      "absolute inset-0 h-4 w-4 transition-all",
-                                      copiedId === media.id
-                                        ? "scale-0 opacity-0 blur-sm"
-                                        : "scale-100 opacity-100 blur-0",
-                                    )}
-                                  />
-                                </button>
-                                <button
-                                  type="button"
-                                  className="cursor-pointer text-muted-foreground hover:text-foreground"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    handleDownload(media.path, media.name);
-                                  }}
-                                  aria-label="Download"
-                                >
-                                  <Download className="h-4 w-4" />
-                                </button>
-                                <button
-                                  type="button"
-                                  className="cursor-pointer text-muted-foreground hover:text-destructive"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    setTimeout(
-                                      () => setDeleteMediaTarget(media),
-                                      0,
-                                    );
-                                  }}
-                                  aria-label="Delete"
-                                >
-                                  <Trash2 className="h-4 w-4" />
-                                </button>
-                              </div>
-                            ) : (
-                              <span className="text-xs text-muted-foreground">
-                                {formatListDate(media.mtime)}
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                      </ContextMenuTrigger>
-                      {!isHovered && openMenuId !== media.id ? null : selectionMode ? (
-                        renderBulkContextMenuContent()
-                      ) : (
-                        <ContextMenuContent className="w-64">
-                          <ContextMenuItem onClick={() => onMediaSelect(media)}>
-                            <File className="h-4 w-4" />
-                            Open
-                          </ContextMenuItem>
-                          <ContextMenuItem
-                            onClick={() =>
-                              setTimeout(() => setRenameTarget(media), 0)
-                            }
-                          >
-                            <Pencil className="h-4 w-4" />
-                            Rename
-                          </ContextMenuItem>
-                          <ContextMenuItem
-                            onClick={() => handleCopyMedia(media.path)}
-                          >
-                            <Copy className="h-4 w-4" />
-                            Make a copy
-                          </ContextMenuItem>
-                          <ContextMenuSub>
-                            <ContextMenuSubTrigger>
-                              <Move className="h-4 w-4" />
-                              Move to
-                            </ContextMenuSubTrigger>
-                            <ContextMenuSubContent
-                              className="w-48 max-h-[400px] overflow-y-auto"
+                        </ContextMenuTrigger>
+                        {!isHovered &&
+                        openMenuId !== media.id ? null : selectionMode ? (
+                          renderBulkContextMenuContent()
+                        ) : (
+                          <ContextMenuContent className="w-64">
+                            <ContextMenuItem
+                              onClick={() => onMediaSelect(media)}
                             >
-                              <MoveToNavigator
-                                ItemComponent={ContextMenuItem}
-                                currentDir={currentDir}
-                                onSelect={(path) =>
-                                  setMoveMediaTarget({
-                                    media,
-                                    destination: path,
-                                  })
-                                }
-                              />
-                            </ContextMenuSubContent>
-                          </ContextMenuSub>
-                          <ContextMenuItem
-                            onClick={() => handleCopyUrl(media.path)}
-                          >
-                            <Link2 className="h-4 w-4" />
-                            Copy URL
-                          </ContextMenuItem>
-                          <ContextMenuItem
-                            onClick={() =>
-                              handleDownload(media.path, media.name)
-                            }
-                          >
-                            <Download className="h-4 w-4" />
-                            Download
-                            <ContextMenuShortcut>
-                              {mac ? "⇧⌘D" : "Ctrl Shift D"}
-                            </ContextMenuShortcut>
-                          </ContextMenuItem>
-                          <ContextMenuSeparator />
-                          <ContextMenuItem
-                            onClick={() =>
-                              setTimeout(() => setDeleteMediaTarget(media), 0)
-                            }
-                            variant="destructive"
-                          >
-                            <Trash2 className="h-4 w-4" />
-                            Delete
-                          </ContextMenuItem>
-                        </ContextMenuContent>
-                      )}
-                    </ContextMenu>
+                              <File className="h-4 w-4" />
+                              Open
+                            </ContextMenuItem>
+                            <ContextMenuItem
+                              onClick={() =>
+                                setTimeout(() => setRenameTarget(media), 0)
+                              }
+                            >
+                              <Pencil className="h-4 w-4" />
+                              Rename
+                            </ContextMenuItem>
+                            <ContextMenuItem
+                              onClick={() => handleCopyMedia(media.path)}
+                            >
+                              <Copy className="h-4 w-4" />
+                              Make a copy
+                            </ContextMenuItem>
+                            <ContextMenuSub>
+                              <ContextMenuSubTrigger>
+                                <Move className="h-4 w-4" />
+                                Move to
+                              </ContextMenuSubTrigger>
+                              <ContextMenuSubContent className="w-48 max-h-[400px] overflow-y-auto">
+                                <MoveToNavigator
+                                  ItemComponent={ContextMenuItem}
+                                  currentDir={currentDir}
+                                  onSelect={(path) =>
+                                    setMoveMediaTarget({
+                                      media,
+                                      destination: path,
+                                    })
+                                  }
+                                />
+                              </ContextMenuSubContent>
+                            </ContextMenuSub>
+                            <ContextMenuItem
+                              onClick={() => handleCopyUrl(media.path)}
+                            >
+                              <Link2 className="h-4 w-4" />
+                              Copy URL
+                            </ContextMenuItem>
+                            <ContextMenuItem
+                              onClick={() =>
+                                handleDownload(media.path, media.name)
+                              }
+                            >
+                              <Download className="h-4 w-4" />
+                              Download
+                              <ContextMenuShortcut>
+                                {mac ? "⇧⌘D" : "Ctrl Shift D"}
+                              </ContextMenuShortcut>
+                            </ContextMenuItem>
+                            <ContextMenuSeparator />
+                            <ContextMenuItem
+                              onClick={() =>
+                                setTimeout(() => setDeleteMediaTarget(media), 0)
+                              }
+                              variant="destructive"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                              Delete
+                            </ContextMenuItem>
+                          </ContextMenuContent>
+                        )}
+                      </ContextMenu>
                     </div>
                   );
                 })}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,9 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.14.5
         version: 3.14.5(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      border-beam:
+        specifier: ^1.3.0
+        version: 1.3.0(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -4349,6 +4352,12 @@ packages:
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
+
+  border-beam@1.3.0:
+    resolution: {integrity: sha512-oZSISp3aQau4ASTmzm5pzxeBinO6Fh2HW0gyEixJgtpUZvRiU0vNpP+IwGRrNpIyqPjA7Rf5EBnVqDSJ49cm5w==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   bowser@2.11.0:
     resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
@@ -11988,6 +11997,11 @@ snapshots:
       type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  border-beam@1.3.0(react-dom@19.1.2(react@19.1.2))(react@19.1.2):
+    dependencies:
+      react: 19.1.2
+      react-dom: 19.1.2(react@19.1.2)
 
   bowser@2.11.0: {}
 


### PR DESCRIPTION
Wraps the empty state upload button in [`border-beam`](https://github.com/Jakubantalik/border-beam), and opens the component up to consumers.

## What changed

- `MediaGrid`'s empty state upload button is wrapped in `BorderBeam`.
- `BorderBeam` is re-exported from `@openinary/ui` as-is, with no wrapper, so consumers keep its full prop surface (`colorVariant`, `strength`, `brightness`, `duration`, `hueRange`, etc.). The emitted `.d.ts` re-exports straight from the source package, so new props arrive without touching `index.ts`.
- `MediaGrid` gains a `beamProps` override for the internal beam:

```tsx
<MediaGrid
  onMediaSelect={handleSelect}
  beamProps={{ colorVariant: "sunset", strength: 0.2 }}
/>
```

  Typed `Omit<BorderBeamProps, "children">` and spread last, so any subset of props wins over the defaults. Pass `active: false` to stop the animation.

## Notes

`theme` is driven from next themes' `resolvedTheme` rather than the component's own `"auto"` mode. That mode reads `prefers-color-scheme`, which never sees the class based toggle in the appearance settings, so the beam would keep dark colors on a light background.

The dependency is declared in `dependencies`, so tsup externalizes it and consumers get it transitively. No CSS to import: the component renders its own `<style>` inline, and `dist/` ships no stylesheet.

## Verification

- `type-check` and `build` pass on `@openinary/ui`.
- Prop typing checked end to end from `apps/web` through the built `dist`, both directions: valid props compile, and an invalid `colorVariant` is rejected with `TS2322`.
- The two commits are split, feature and formatting. The `style` commit is provably whitespace and trailing commas only: stripping both from either side gives identical hashes.

**Not visually verified.** The empty state sits behind the login and only renders at the root with zero folders and zero files, so it needs a look before merge.

Bumping `@openinary/ui` is still needed to publish, since this adds a runtime dependency and two public API entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)