### PR TITLE
chore: land the 0.6.0 bump on main, stop package tags rebuilding the image

### DIFF
--- a/.github/workflows/basebuild.yml
+++ b/.github/workflows/basebuild.yml
@@ -5,8 +5,10 @@ on:
     branches:
       - main
     tags:
+      # No bare '*.*.*': '*' matches everything but '/', so it swallowed every
+      # package tag too (ui-v0.6.0, core-v*, cli-v*) and rebuilt the image on
+      # each npm release. App releases are all 'vX.Y.Z', already covered above.
       - 'v*'
-      - '*.*.*'
     paths:
       - 'docker/**'
       - 'apps/**'

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -110,6 +110,21 @@ tree (`next-themes` is a peer dependency, same reasoning as `react-query`).
 custom action/cancel/close styling) — render it instead of importing
 `Toaster` from `sonner` directly, so toasts look the same as the dashboard.
 
+`BorderBeam` is re-exported from [`border-beam`](https://github.com/Jakubantalik/border-beam)
+untouched, so it keeps its full prop surface (`colorVariant`, `strength`,
+`brightness`, `duration`, `hueRange`, …). `MediaGrid` uses it around the empty
+state's upload button; pass `beamProps` to restyle that one, or `active: false`
+to stop it animating:
+
+```tsx
+<MediaGrid
+  onMediaSelect={handleSelect}
+  beamProps={{ colorVariant: "sunset", strength: 0.2 }}
+/>
+```
+
+It renders its own `<style>` inline, so there is no stylesheet to import.
+
 **Not included**, by design — these are coupled to Openinary's self-hosted,
 single-admin auth model and don't generalize to other apps' auth:
 authentication UI (login/API-key management) and anything importing

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openinary/ui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Openinary's dashboard UI components, hooks and design primitives as a standalone, embeddable React package.",
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Two pieces of fallout from the `ui-v0.6.0` release.

## 1. `main` was left at 0.5.0 while npm got 0.6.0

PR #108 was squash-merged at `09:40:21Z`. The `chore(ui): bump to 0.6.0` commit was pushed to the branch at `09:40:23Z`, two seconds later, so it never entered the PR and never reached `main`. The tag `ui-v0.6.0` was then placed on that orphaned branch commit, which published fine but left `main` out of sync:

- `main` said `0.5.0`, npm had `0.6.0`
- the README docs for `BorderBeam` and `beamProps` were missing from `main`
- the next attempt to release `0.6.0` would have been rejected by npm, since a published version cannot be republished

The published artifact itself is correct: the tarball on npm has `version 0.6.0`, `border-beam` as a dependency, and `BorderBeam` in the emitted `.d.ts`. Only `main` was wrong. This re-applies the bump and the README section, and `packages/ui` on this branch is now byte identical to the `ui-v0.6.0` tree.

## 2. Package tags were triggering `basebuild`

`basebuild.yml` filtered tags on `'v*'` and `'*.*.*'`. In GitHub Actions patterns `*` matches any character except `/`, so `'*.*.*'` matched **any ref with at least two dots**, including every package tag. Pushing `ui-v0.6.0` fired `basebuild` ([run 30532749417](https://github.com/openinary/openinary/actions/runs/30532749417)) alongside the intended `publish-ui` ([run 30532749452](https://github.com/openinary/openinary/actions/runs/30532749452)), rebuilding the Docker image that the merge to `main` had already built 17 minutes earlier.

This was firing on every npm release, not just this one. Checked against the full tag list: all 16 app release tags (`v0.1.0` through `v0.3.0`) still match `'v*'`, and all 16 package tags (`ui-v*`, `core-v*`, `cli-v*`) are now skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)