### PR TITLE
fix(web): keep self-hosted dashboards out of search engines

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -123,6 +123,15 @@ function addCorsHeaders(
 }
 
 export async function middleware(request: NextRequest) {
+  const response = await handleRequest(request);
+  // Self-hosted dashboards were turning up in search results. Every response
+  // the dashboard serves is private, so tell crawlers to drop the lot -- the
+  // header rides along on the /login redirect too, which a <meta> tag can't do.
+  response.headers.set("X-Robots-Tag", "noindex, nofollow");
+  return response;
+}
+
+async function handleRequest(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const allowedOrigin = getAllowedOrigin();
   const requestOrigin = request.headers.get("origin");


### PR DESCRIPTION
**TL;DR:** self-hosted instances were showing up in Google. Every dashboard response now sends `X-Robots-Tag: noindex, nofollow`.

- Set in middleware, so it also rides the `307 /` to `/login`. A `<meta>` tag can't, a redirect has no HTML.
- No `robots.txt`: a `Disallow` blocks the recrawl that makes Google *see* the noindex, so already-indexed instances would stay indexed.
- Scoped to `apps/web`. Media delivery (`/t`, `/download` on the API) stays crawlable, so user image SEO is untouched.

Verified locally: header present on `/` (307), `/login`, `/setup`, `/api/version`, `/api-keys`.