### PR TITLE
fix(core): probe a remote source with GET, not HEAD

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @openinary/core
 
+## 1.4.1
+
+### Patch Changes
+
+- Probe a remote source with GET, not HEAD
+
+  A presigned URL authorizes exactly one method — SigV4 signs the verb into the
+  string it signs — so a URL issued for GET answers 403 to a HEAD. The existence
+  check introduced in 1.4.0 used HEAD, which reported every object that exists as
+  missing and meant no transform against a remote source ever ran.
+
+  It now asks for one byte over GET (`Range: bytes=0-0`). An absent key still
+  answers 404, so nothing is lost by asking this way.
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openinary/core",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Openinary's media transformation engine and route handlers (image/video processing, storage, job queue) as a standalone, embeddable package.",
   "type": "module",
   "license": "AGPL-3.0-only",

--- a/packages/core/src/routes/remote-source.test.ts
+++ b/packages/core/src/routes/remote-source.test.ts
@@ -1,7 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFile, rm } from "node:fs/promises";
-import { remoteSourceUrl, prepareSourceFile } from "./transform-helpers";
+import {
+  remoteSourceUrl,
+  prepareSourceFile,
+  verifyFileExists,
+} from "./transform-helpers";
 
 const ctx = (headers: Record<string, string>): any => ({
   req: { header: (name: string) => headers[name.toLowerCase()] },
@@ -81,6 +85,49 @@ test("a source URL is staged to a temp file, ahead of storage", async () => {
     assert.match(staged, /^\.?\/?temp\//, "staged under ./temp");
     assert.deepEqual([...(await readFile(staged))], [1, 2, 3, 4]);
     await rm(staged, { force: true });
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+// --- checking the source exists ----------------------------------------
+
+// The regression this exists for. A presigned URL authorizes one method:
+// SigV4 signs the verb, so a URL issued for GET answers 403 to a HEAD. Probing
+// with HEAD reported every existing object as missing, and the transform never
+// ran - against real S3-compatible storage, where a HEAD-signed URL would then
+// have broken the download instead.
+test("existence is probed with GET, never HEAD", async () => {
+  const realFetch = globalThis.fetch;
+  const seen: { method: string; range: string | null }[] = [];
+  globalThis.fetch = (async (_url: any, init: any) => {
+    seen.push({
+      method: init?.method ?? "GET",
+      range: new Headers(init?.headers).get("range"),
+    });
+    // What Filebase, R2 and S3 all answer to a signed GET carrying a range.
+    return new Response(new Uint8Array([1]), { status: 206 });
+  }) as typeof fetch;
+
+  try {
+    const check = await verifyFileExists(null, "photos/a.png", "", SIGNED);
+    assert.equal(check.exists, true);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].method, "GET", "HEAD is refused by a GET-signed URL");
+    assert.equal(seen[0].range, "bytes=0-0", "one byte, not the whole object");
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test("an absent object still reads as not found", async () => {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response("", { status: 404 })) as typeof fetch;
+  try {
+    const check = await verifyFileExists(null, "photos/gone.png", "", SIGNED);
+    assert.equal(check.exists, false);
+    assert.match(check.error ?? "", /404/);
   } finally {
     globalThis.fetch = realFetch;
   }

--- a/packages/core/src/routes/transform-helpers.ts
+++ b/packages/core/src/routes/transform-helpers.ts
@@ -210,12 +210,22 @@ export async function verifyFileExists(
   sourceUrl?: string
 ): Promise<{ exists: boolean; isCloud: boolean; error?: string }> {
   if (sourceUrl) {
-    // A HEAD rather than trusting the caller: a signed URL that has expired, or
-    // names an object since deleted, has to read as "not found" right here.
-    // Left unchecked it surfaces much later as a truncated download inside
-    // sharp or ffmpeg, where the error says nothing about the real cause.
+    // Checked rather than trusted: a URL that has expired, or names an object
+    // since deleted, has to read as "not found" right here. Left unchecked it
+    // surfaces much later as a truncated download inside sharp or ffmpeg,
+    // where the error says nothing about the real cause.
+    //
+    // One byte over GET, never HEAD. A presigned URL authorizes exactly one
+    // method - SigV4 signs the verb into the string it signs - so a URL issued
+    // for GET answers 403 to a HEAD, which would read as "missing" for every
+    // object that exists. A range still 404s on an absent key, so nothing is
+    // lost by asking this way.
     try {
-      const response = await fetch(sourceUrl, { method: "HEAD" });
+      const response = await fetch(sourceUrl, {
+        headers: { Range: "bytes=0-0" },
+      });
+      // Nothing reads the byte; releasing it keeps the connection reusable.
+      await response.body?.cancel();
       if (response.ok) return { exists: true, isCloud: true };
       return {
         exists: false,


### PR DESCRIPTION
1.4.0 shipped the remote-source check using `HEAD`. A presigned URL authorizes exactly one method — SigV4 signs the verb into the string it signs — so a URL issued for `GET` answers **403** to a `HEAD`.

Every object that exists therefore reported as missing, and no transform against a remote source ever ran. Caught on the first real request against Filebase; the unit tests stubbed `fetch` and never saw it.

Measured against a real presigned URL:

| request | answer |
|---|---|
| `HEAD` | 403 |
| `GET` + `Range: bytes=0-0` | 206, 1 byte |
| `GET` + range, absent key | 404 |

So it now asks for one byte over GET. An absent key still 404s, which means the check keeps telling "not there" apart from "broken" — the reason it exists.

Includes a regression test that drives `verifyFileExists` and asserts the method and range; it fails on the `HEAD` version.

Ships as 1.4.1 with the version bump and CHANGELOG, so merging leaves only the `core-v1.4.1` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)