### PR TITLE
fix(ui): percent-encode storage paths in every URL

### DIFF
--- a/.changeset/rotten-buttons-hammer.md
+++ b/.changeset/rotten-buttons-hammer.md
@@ -1,0 +1,16 @@
+---
+"@openinary/ui": minor
+---
+
+Percent-encode storage paths in every URL the package builds.
+
+Paths were interpolated raw into the `/t/` delivery, preview and thumbnail
+URLs and into the `/video-status` poll, so a filename containing `#` or `?`
+truncated the URL: the browser read everything after it as a fragment or
+query, and the request that reached the server was for the part before it.
+A video uploaded as `The #1 clip.mp4` was fetched as `The ` and 404'd, with
+no broken thumbnail to explain why.
+
+The one-off `split("/").map(encodeURIComponent).join("/")` that the API calls
+already used is now a single exported `encodePath` helper, used everywhere a
+path becomes part of a URL.

--- a/packages/ui/src/components/delete-folder-button.tsx
+++ b/packages/ui/src/components/delete-folder-button.tsx
@@ -8,6 +8,7 @@ import { invalidateStorage } from "../hooks/use-storage-tree";
 import { useOpeninary } from "../provider/openinary-provider";
 import { toast } from "sonner";
 import { DeleteConfirmDialog } from "./delete-confirm-dialog";
+import { encodePath } from "../lib/utils";
 
 export function DeleteFolderButton({
   folderPath,
@@ -21,12 +22,7 @@ export function DeleteFolderButton({
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const handleDelete = async () => {
-    // Encode each segment of the path separately to preserve slashes
-    // This is necessary for files in subdirectories
-    const encodedPath = folderPath
-      .split("/")
-      .map((segment) => encodeURIComponent(segment))
-      .join("/");
+    const encodedPath = encodePath(folderPath);
 
     const deleteUrl = `${apiBaseUrl}/storage/${encodedPath}`;
 

--- a/packages/ui/src/details-sidebar/asset-transformations-tab.tsx
+++ b/packages/ui/src/details-sidebar/asset-transformations-tab.tsx
@@ -3,6 +3,7 @@
 import { Sparkles } from "lucide-react";
 import { CopyInput } from "../ui/copy-input";
 import type { MediaFile } from "../types";
+import { encodePath } from "../lib/utils";
 
 interface AssetTransformationsTabProps {
   asset: MediaFile;
@@ -18,11 +19,11 @@ export function AssetTransformationsTab({ asset, apiBaseUrl }: AssetTransformati
           Common Transformations
         </h3>
         <div className="space-y-2">
-          <CopyInput label="Thumbnail (300x300)" value={`${apiBaseUrl}/t/w_300,h_300/${asset.path}`} />
-          <CopyInput label="Medium (800x800)" value={`${apiBaseUrl}/t/w_800,h_800/${asset.path}`} />
-          <CopyInput label="Large (1920x1080)" value={`${apiBaseUrl}/t/w_1920,h_1080/${asset.path}`} />
-          <CopyInput label="WebP Format" value={`${apiBaseUrl}/t/f_webp/${asset.path}`} />
-          <CopyInput label="Quality 80" value={`${apiBaseUrl}/t/q_80/${asset.path}`} />
+          <CopyInput label="Thumbnail (300x300)" value={`${apiBaseUrl}/t/w_300,h_300/${encodePath(asset.path)}`} />
+          <CopyInput label="Medium (800x800)" value={`${apiBaseUrl}/t/w_800,h_800/${encodePath(asset.path)}`} />
+          <CopyInput label="Large (1920x1080)" value={`${apiBaseUrl}/t/w_1920,h_1080/${encodePath(asset.path)}`} />
+          <CopyInput label="WebP Format" value={`${apiBaseUrl}/t/f_webp/${encodePath(asset.path)}`} />
+          <CopyInput label="Quality 80" value={`${apiBaseUrl}/t/q_80/${encodePath(asset.path)}`} />
         </div>
       </div>
     </div>

--- a/packages/ui/src/details-sidebar/use-asset-details.ts
+++ b/packages/ui/src/details-sidebar/use-asset-details.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { toAbsoluteUrl } from "../lib/utils";
+import { encodePath, toAbsoluteUrl } from "../lib/utils";
 import { useOpeninary } from "../provider/openinary-provider";
 import { getMediaType } from "../media-type";
 import { invalidateStorage } from "../hooks/use-storage-tree";
@@ -26,11 +26,7 @@ export function useAssetDetails(
 
   const fetchFileMetadata = async (path: string) => {
     try {
-      // Encode each segment of the path separately to preserve slashes
-      const encodedPath = path
-        .split("/")
-        .map((segment) => encodeURIComponent(segment))
-        .join("/");
+      const encodedPath = encodePath(path);
 
       const response = await fetch(`${apiBaseUrl}/storage/${encodedPath}/metadata`, {
         method: "GET",
@@ -95,12 +91,12 @@ export function useAssetDetails(
   // Resolve to an absolute URL so Copy URL / Open / the displayed field all
   // produce a shareable link even when transformBaseUrl is empty (same-origin
   // Docker deployments where the bundle was built with NEXT_PUBLIC_API_BASE_URL=/api).
-  const mediaUrl = asset ? toAbsoluteUrl(`${transformBaseUrl}/t/${asset.path}`) : "";
+  const mediaUrl = asset ? toAbsoluteUrl(`${transformBaseUrl}/t/${encodePath(asset.path)}`) : "";
   // For preview: use thumbnail extraction for videos with crop mode to avoid stretching
   const previewUrl = asset
     ? asset.type === "image"
-      ? `${transformBaseUrl}/t/w_500,h_500,q_80/${asset.path}`
-      : `${transformBaseUrl}/t/t_true,tt_5,f_webp,w_500,h_500,c_fill,q_80/${asset.path}`
+      ? `${transformBaseUrl}/t/w_500,h_500,q_80/${encodePath(asset.path)}`
+      : `${transformBaseUrl}/t/t_true,tt_5,f_webp,w_500,h_500,c_fill,q_80/${encodePath(asset.path)}`
     : "";
 
   // Preload preview media when asset changes
@@ -116,10 +112,7 @@ export function useAssetDetails(
 
   const handleDownload = () => {
     if (!asset) return;
-    const downloadUrl = `${apiBaseUrl}/download/${asset.path
-      .split("/")
-      .map((s) => encodeURIComponent(s))
-      .join("/")}`;
+    const downloadUrl = `${apiBaseUrl}/download/${encodePath(asset.path)}`;
     const a = document.createElement("a");
     a.href = downloadUrl;
     a.download = asset.name;
@@ -155,12 +148,7 @@ export function useAssetDetails(
     const assetName = asset.name;
 
     const del = async () => {
-      // Encode each segment of the path separately to preserve slashes
-      // This is necessary for files in subdirectories
-      const encodedPath = asset.path
-        .split("/")
-        .map((segment) => encodeURIComponent(segment))
-        .join("/");
+      const encodedPath = encodePath(asset.path);
 
       const deleteUrl = `${apiBaseUrl}/storage/${encodedPath}`;
 

--- a/packages/ui/src/hooks/use-video-status.ts
+++ b/packages/ui/src/hooks/use-video-status.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useOpeninary } from "../provider/openinary-provider";
 import { useQueueEvents } from "./use-queue-events";
+import { encodePath } from "../lib/utils";
 
 export type VideoStatus = "unknown" | "processing" | "ready" | "error";
 
@@ -93,7 +94,9 @@ export function useVideoStatus(videoPath: string | null, enabled: boolean = true
 
     const checkStatus = async () => {
       try {
-        const response = await fetch(`${apiBaseUrl}/video-status/${videoPath}`);
+        const response = await fetch(
+          `${apiBaseUrl}/video-status/${encodePath(videoPath)}`,
+        );
 
         if (response.ok) {
           const data: VideoStatusResponse = await response.json();

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,7 +3,7 @@
 // banner, not written here — see the build tooling decision in the plan.
 export type { MediaType, MediaFile, StorageFolder, StorageFile, StorageLevel } from "./types";
 export { getMediaType } from "./media-type";
-export { cn, isMac, toAbsoluteUrl } from "./lib/utils";
+export { cn, encodePath, isMac, toAbsoluteUrl } from "./lib/utils";
 export { Spinner } from "./ui/spinner";
 export { Toaster } from "./ui/sonner";
 

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -10,6 +10,26 @@ export function isMac(): boolean {
 }
 
 /**
+ * Percent-encode a storage path for use inside a URL path, one segment at a
+ * time so the "/" separators survive.
+ *
+ * Storage paths are user-supplied filenames, and interpolating one straight
+ * into a URL silently truncates it: "#" starts a fragment and "?" starts a
+ * query, so everything after it is stripped by the browser and never reaches
+ * the server. A video uploaded as "The #1 clip.mp4" was requested as "The "
+ * and 404'd, while the asset itself was perfectly fine.
+ *
+ * Every path that becomes part of a URL goes through this - the /t/ delivery
+ * and thumbnail URLs just as much as the /storage and /download API calls.
+ */
+export function encodePath(path: string): string {
+  return path
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+}
+
+/**
  * Resolve a possibly-relative media/transform URL to an absolute URL.
  *
  * In same-origin deployments (Docker/nginx) the transform base URL is empty,

--- a/packages/ui/src/media-grid.tsx
+++ b/packages/ui/src/media-grid.tsx
@@ -47,7 +47,7 @@ import {
   ContextMenuTrigger,
 } from "./ui/context-menu";
 import { Checkbox } from "./ui/checkbox";
-import { cn, isMac, toAbsoluteUrl } from "./lib/utils";
+import { cn, encodePath, isMac, toAbsoluteUrl } from "./lib/utils";
 import { useOpeninary } from "./provider/openinary-provider";
 import { VideoThumbnail } from "./components/video-thumbnail";
 import { DefaultDialog } from "./components/default-dialog";
@@ -138,7 +138,7 @@ function getFolderThumbnailUrl(
         : size === "tall"
           ? "w_250,h_500"
           : "w_250,h_250";
-    return `${transformBaseUrl}/t/t_true,tt_5,f_webp,${dims},c_fill,q_70/${item.path}`;
+    return `${transformBaseUrl}/t/t_true,tt_5,f_webp,${dims},c_fill,q_70/${encodePath(item.path)}`;
   }
   const dims =
     size === "large"
@@ -146,7 +146,7 @@ function getFolderThumbnailUrl(
       : size === "tall"
         ? "w_250,h_500"
         : "w_250,h_250";
-  return `${transformBaseUrl}/t/${dims},q_70/${item.path}`;
+  return `${transformBaseUrl}/t/${dims},q_70/${encodePath(item.path)}`;
 }
 
 export interface MediaGridProps {
@@ -500,16 +500,13 @@ export function MediaGrid({
   const handleMediaHover = (media: MediaFile) => {
     const previewUrl =
       media.type === "image"
-        ? `${transformBaseUrl}/t/w_500,h_500,q_80/${media.path}`
-        : `${transformBaseUrl}/t/t_true,tt_5,f_webp,w_500,h_500,c_fill,q_80/${media.path}`;
+        ? `${transformBaseUrl}/t/w_500,h_500,q_80/${encodePath(media.path)}`
+        : `${transformBaseUrl}/t/t_true,tt_5,f_webp,w_500,h_500,c_fill,q_80/${encodePath(media.path)}`;
     preloadMedia(previewUrl, "image");
   };
 
   const handleDownload = (path: string, name: string) => {
-    const downloadUrl = `${apiBaseUrl}/download/${path
-      .split("/")
-      .map((s) => encodeURIComponent(s))
-      .join("/")}`;
+    const downloadUrl = `${apiBaseUrl}/download/${encodePath(path)}`;
     const a = document.createElement("a");
     a.href = downloadUrl;
     a.download = name;
@@ -521,7 +518,7 @@ export function MediaGrid({
 
   const handleCopyUrl = (path: string, id?: string) => {
     navigator.clipboard.writeText(
-      toAbsoluteUrl(`${transformBaseUrl}/t/${path}`),
+      toAbsoluteUrl(`${transformBaseUrl}/t/${encodePath(path)}`),
     );
     toast.success("URL copied to clipboard");
     if (id) {
@@ -534,10 +531,7 @@ export function MediaGrid({
   };
 
   const handleRenameMedia = async (path: string, newName: string) => {
-    const encodedPath = path
-      .split("/")
-      .map((s) => encodeURIComponent(s))
-      .join("/");
+    const encodedPath = encodePath(path);
 
     const rename = async () => {
       const response = await fetch(`${apiBaseUrl}/storage/${encodedPath}`, {
@@ -570,10 +564,7 @@ export function MediaGrid({
   };
 
   const handleCopyMedia = async (path: string) => {
-    const encodedPath = path
-      .split("/")
-      .map((s) => encodeURIComponent(s))
-      .join("/");
+    const encodedPath = encodePath(path);
 
     const copy = async () => {
       const response = await fetch(
@@ -604,10 +595,7 @@ export function MediaGrid({
   };
 
   const handleMoveMedia = async (path: string, destination: string) => {
-    const encodedPath = path
-      .split("/")
-      .map((s) => encodeURIComponent(s))
-      .join("/");
+    const encodedPath = encodePath(path);
 
     const move = async () => {
       const response = await fetch(
@@ -640,10 +628,7 @@ export function MediaGrid({
   };
 
   const handleDeleteMedia = async (path: string, name: string) => {
-    const encodedPath = path
-      .split("/")
-      .map((s) => encodeURIComponent(s))
-      .join("/");
+    const encodedPath = encodePath(path);
 
     const del = async () => {
       const response = await fetch(`${apiBaseUrl}/storage/${encodedPath}`, {
@@ -672,10 +657,7 @@ export function MediaGrid({
   };
 
   const handleDownloadFolder = (path: string, name: string) => {
-    const encodedPath = path
-      .split("/")
-      .map((s) => encodeURIComponent(s))
-      .join("/");
+    const encodedPath = encodePath(path);
     const a = document.createElement("a");
     a.href = `${apiBaseUrl}/download-folder/${encodedPath}`;
     a.download = `${name}.zip`;
@@ -686,10 +668,7 @@ export function MediaGrid({
   };
 
   const handleRenameFolder = async (path: string, newName: string) => {
-    const encodedPath = path
-      .split("/")
-      .map((s) => encodeURIComponent(s))
-      .join("/");
+    const encodedPath = encodePath(path);
 
     const rename = async () => {
       const response = await fetch(`${apiBaseUrl}/storage/${encodedPath}`, {
@@ -727,10 +706,7 @@ export function MediaGrid({
   };
 
   const handleDeleteFolder = async (path: string) => {
-    const encodedPath = path
-      .split("/")
-      .map((s) => encodeURIComponent(s))
-      .join("/");
+    const encodedPath = encodePath(path);
 
     const del = async () => {
       const response = await fetch(`${apiBaseUrl}/storage/${encodedPath}`, {
@@ -817,10 +793,7 @@ export function MediaGrid({
     const move = async () => {
       const results = await Promise.allSettled(
         entries.map((entry) => {
-          const encodedPath = entry.path
-            .split("/")
-            .map((s) => encodeURIComponent(s))
-            .join("/");
+          const encodedPath = encodePath(entry.path);
           return fetch(`${apiBaseUrl}/storage/${encodedPath}/move`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -861,10 +834,7 @@ export function MediaGrid({
     const del = async () => {
       const results = await Promise.allSettled(
         entries.map((entry) => {
-          const encodedPath = entry.path
-            .split("/")
-            .map((s) => encodeURIComponent(s))
-            .join("/");
+          const encodedPath = encodePath(entry.path);
           return fetch(`${apiBaseUrl}/storage/${encodedPath}`, {
             method: "DELETE",
           }).then((response) => {
@@ -1636,8 +1606,8 @@ export function MediaGrid({
                           // For videos: extract thumbnail at 1 second as jpg image with crop mode to avoid stretching
                           const thumbnailUrl =
                             media.type === "image"
-                              ? `${transformBaseUrl}/t/w_500,h_500,q_80/${media.path}`
-                              : `${transformBaseUrl}/t/t_true,tt_5,f_webp,w_500,h_500,c_fill,q_80/${media.path}`;
+                              ? `${transformBaseUrl}/t/w_500,h_500,q_80/${encodePath(media.path)}`
+                              : `${transformBaseUrl}/t/t_true,tt_5,f_webp,w_500,h_500,c_fill,q_80/${encodePath(media.path)}`;
                           const isHovered = hoveredId === media.id;
 
                           return (
@@ -1822,8 +1792,8 @@ export function MediaGrid({
                   // second thumbnail variant.
                   const thumbnailUrl =
                     media.type === "image"
-                      ? `${transformBaseUrl}/t/w_500,h_500,q_80/${media.path}`
-                      : `${transformBaseUrl}/t/t_true,tt_5,f_webp,w_500,h_500,c_fill,q_80/${media.path}`;
+                      ? `${transformBaseUrl}/t/w_500,h_500,q_80/${encodePath(media.path)}`
+                      : `${transformBaseUrl}/t/t_true,tt_5,f_webp,w_500,h_500,c_fill,q_80/${encodePath(media.path)}`;
 
                   return (
                     <div

--- a/packages/ui/test/encode-path.test.ts
+++ b/packages/ui/test/encode-path.test.ts
@@ -1,0 +1,38 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { encodePath } from "../src/lib/utils";
+
+const BASE = "https://cdn.example.com/b/buck_1/t";
+
+test("a path with # survives the URL it is interpolated into", () => {
+  // The bug this guards: a video uploaded as "The #1 clip.mp4" produced a
+  // delivery URL the browser cut at the "#", so the request that reached the
+  // CDN was for "…/VAULT/The%20" and 404'd on an asset that existed.
+  const path = "VAULT/The #1 clip.mp4";
+
+  const broken = new URL(`${BASE}/${path}`);
+  assert.equal(broken.pathname.endsWith(".mp4"), false);
+  assert.notEqual(broken.hash, "");
+
+  const fixed = new URL(`${BASE}/${encodePath(path)}`);
+  assert.equal(fixed.hash, "");
+  assert.equal(
+    decodeURIComponent(fixed.pathname.slice("/b/buck_1/t/".length)),
+    path,
+  );
+});
+
+test("? does not start a query string", () => {
+  const url = new URL(`${BASE}/${encodePath("what now?.png")}`);
+  assert.equal(url.search, "");
+  assert.equal(decodeURIComponent(url.pathname), "/b/buck_1/t/what now?.png");
+});
+
+test("separators are kept, everything else in a segment is encoded", () => {
+  assert.equal(encodePath("a/b/c.png"), "a/b/c.png");
+  assert.equal(encodePath("Vidéos/Été 2026/plage.mov"), "Vid%C3%A9os/%C3%89t%C3%A9%202026/plage.mov");
+  // A literal "%" has to become "%25", or the server's decode turns
+  // "50%20off.mp4" into a lookup for "50 off.mp4".
+  assert.equal(encodePath("50%20off.mp4"), "50%2520off.mp4");
+  assert.equal(encodePath(""), "");
+});


### PR DESCRIPTION
## The bug

A user reported that one of their videos wouldn't play. The URL the dashboard gave them:

```
https://cdn.openinary.dev/b/<bucket>/t/OPTIMIZED/VAULT/The%20#1%20Most%20…%20[wfGghA2NQUg].mp4
```

The `#` is a fragment delimiter. The browser never sends it or anything after it, so the request that actually reached the CDN was for `…/t/OPTIMIZED/VAULT/The%20` — a 404 on a file that exists and is perfectly healthy in R2.

Reproducing it takes one line, and it returns exactly the URL the user was given:

```js
new URL("VAULT/The #1 clip.mp4", "https://cdn.example.com/b/x/t/OPTIMIZED/").href
```

## Cause

The package interpolated `asset.path` straight into every URL that addresses media:

- `useAssetDetails` — `mediaUrl` (the **Copy URL** field) and `previewUrl`
- `AssetTransformationsTab` — the five `CopyInput` presets
- `MediaGrid` — grid and list thumbnails, the video thumbnail builder, and the copy-URL handler
- `useVideoStatus` — the `/video-status` poll, which is why the asset also looked stuck rather than broken

Meanwhile every *API* call in the package already encoded correctly, via an inline `path.split("/").map(encodeURIComponent).join("/")` copied out 14 times. There was no named helper to reach for, so the URLs that matter most were written raw.

`?` truncates the same way (query string), and a literal `%` is worse than truncation: it round-trips as a *different* key, because the server decodes. `50%20off.mp4` gets looked up as `50 off.mp4`.

## The change

One exported `encodePath` in `lib/utils`, used at all 18 sites — the 17 that were broken and the 14 inline copies that were already right, so there is now a single way to put a path in a URL. Net −22 lines.

Spaces and accents are unaffected: `new URL` already handled those, and they still encode to the same `%20` / `%C3%A9` they always did. No delivery URL changes for any filename that worked before.

## Notes

- `encodePath` is exported from the package root — `openinary-cloud`'s playground builds `/t/` URLs the same way and can drop its own copy.
- The server side already decodes per segment (`parseCdnRequest`, `extractFilePath`, the `/video-status` route), so encoded paths resolve without any server change.
- Assets **already stored** with a `#` in the key stay unreachable through a naively-built URL until they're renamed — this fixes URL construction, not existing keys. A companion server-side guard strips `#`, `?`, `%` and control characters at upload so no new key can hit this.

## Verification

`pnpm type-check`, `pnpm build` and `pnpm test` pass in `packages/ui` (7 tests: 4 existing + 3 new in `test/encode-path.test.ts`, which pin that a `#` path survives the URL round trip and that separators are kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)