### PR TITLE
fix(ui): fold the downstream dist patch back into source

### DIFF
--- a/.changeset/silver-melons-repeat.md
+++ b/.changeset/silver-melons-repeat.md
@@ -1,0 +1,20 @@
+---
+"@openinary/ui": patch
+---
+
+Fold four fixes that had been living as a downstream `pnpm patch` back into
+the source:
+
+- **AssetPreview no longer gets stuck on a grey square.** Its loading state
+  was reset in an effect keyed on `previewUrl`, but `usePreloadMedia` warms
+  the same URL - on a revisit the cached `<img>` fired `load` before the
+  passive effect ran, which then flipped loading back on with no event left
+  to clear it. State is now keyed by URL.
+- **Folder uploads filter by accepted type.** `webkitdirectory` ignores the
+  input's `accept`, so picking a folder handed over every file inside it and
+  one stray `.txt` made the API reject the whole batch. It now runs through
+  the same `validateFile`/`DEFAULT_ACCEPT` check as the dropzone.
+- **Toasts stay centred.** `!w-fit` dropped the width sonner positions
+  against, so the pill drifted off-centre as its text changed length.
+- **Settings dialog is roomier** (600x750), and the empty state's trailing
+  arrow uses a left margin rather than a right one.

--- a/packages/ui/src/components/upload-section.tsx
+++ b/packages/ui/src/components/upload-section.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 import { useDropzone } from "react-dropzone";
-import { DEFAULT_ACCEPT } from "../file-uploader/use-file-upload";
+import { DEFAULT_ACCEPT, validateFile } from "../file-uploader/use-file-upload";
 
 interface UploadResult {
   filename: string;
@@ -68,8 +68,15 @@ export function UploadSection({ uploadToFolder }: { uploadToFolder?: string }) {
   });
 
   const handleFolderSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // webkitdirectory ignores the input's `accept`, so a folder picked here
+    // hands over everything inside it - the dropzone above filters by
+    // DEFAULT_ACCEPT, this path did not, and a single stray .txt or .zip made
+    // the API reject the whole batch. Size is left to the server (Infinity):
+    // this component has no per-plan limit to check against.
     const files = Array.from(e.target.files || []).filter(
-      (file) => !isIgnoredFile(file),
+      (file) =>
+        !isIgnoredFile(file) &&
+        validateFile(file, DEFAULT_ACCEPT, Number.POSITIVE_INFINITY) === null,
     );
     if (files.length > 0) {
       setSelectedFiles(files);

--- a/packages/ui/src/details-sidebar/asset-preview.tsx
+++ b/packages/ui/src/details-sidebar/asset-preview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Skeleton } from "../ui/skeleton";
 import { VideoThumbnail } from "../components/video-thumbnail";
 import type { MediaFile } from "../types";
@@ -11,22 +11,22 @@ interface AssetPreviewProps {
 }
 
 export function AssetPreview({ asset, previewUrl }: AssetPreviewProps) {
-  const [isLoading, setIsLoading] = useState(true);
-  const [hasError, setHasError] = useState(false);
-
-  // Reset loading state when previewUrl changes
-  useEffect(() => {
-    setIsLoading(true);
-    setHasError(false);
-  }, [previewUrl]);
+  // Keyed by URL rather than reset in an effect. usePreloadMedia warms the
+  // same URL, so on a revisit the <img> is served from cache and fires load
+  // before the passive effect runs - the effect then set isLoading back to
+  // true with no load event left to clear it, and the preview stayed an empty
+  // grey square until the sidebar was closed and reopened.
+  const [loadedUrl, setLoadedUrl] = useState<string | null>(null);
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
+  const isLoading = loadedUrl !== previewUrl && failedUrl !== previewUrl;
+  const hasError = failedUrl === previewUrl;
 
   const handleLoad = () => {
-    setIsLoading(false);
+    setLoadedUrl(previewUrl);
   };
 
   const handleError = () => {
-    setIsLoading(false);
-    setHasError(true);
+    setFailedUrl(previewUrl);
   };
 
   return (
@@ -45,6 +45,10 @@ export function AssetPreview({ asset, previewUrl }: AssetPreviewProps) {
               <Skeleton className="absolute inset-0 w-full h-full" />
             )}
             <img
+              // Fresh element per URL, so the load event is guaranteed to
+              // fire for the URL the state above is keyed on rather than
+              // being swallowed by a reused node that already loaded.
+              key={previewUrl}
               src={previewUrl}
               alt={asset.name}
               className={`w-full h-full object-contain transition-opacity duration-200 ${

--- a/packages/ui/src/media-grid.tsx
+++ b/packages/ui/src/media-grid.tsx
@@ -482,7 +482,7 @@ export function MediaGrid({
               target="_blank"
               rel="noopener noreferrer"
             >
-              Learn More <ArrowUpRight className="mr-2 h-4 w-4" />
+              Learn More <ArrowUpRight className="ml-1 h-4 w-4" />
             </a>
           </Button>
         </Empty>

--- a/packages/ui/src/settings/settings-dialog.tsx
+++ b/packages/ui/src/settings/settings-dialog.tsx
@@ -35,7 +35,7 @@ export function SettingsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex h-[520px] max-w-2xl gap-0 overflow-hidden p-0">
+      <DialogContent className="flex h-[600px] max-w-[750px] gap-0 overflow-hidden p-0">
         <DialogTitle className="sr-only">Settings</DialogTitle>
         <div className="flex w-48 shrink-0 flex-col gap-0.5 border-r bg-muted/30 px-3 py-4">
           <span className="px-2 pb-3 text-xs font-medium text-muted-foreground">

--- a/packages/ui/src/ui/sonner.tsx
+++ b/packages/ui/src/ui/sonner.tsx
@@ -22,8 +22,12 @@ const Toaster = ({ ...props }: ToasterProps) => {
       toastOptions={{
         unstyled: false,
         classNames: {
+          // inset-x-0 + mx-auto because "!w-fit" above drops the width sonner
+          // positions against: without them the pill is laid out from the
+          // container's left edge and drifts off-centre as its text changes
+          // length, instead of staying centred under the cursor's eye.
           toast:
-            "!w-fit !max-w-[90vw] !rounded-full !gap-3 !py-2.5 !px-4 !shadow-lg",
+            "!w-fit !max-w-[90vw] !rounded-full !gap-3 !py-2.5 !px-4 !shadow-lg !inset-x-0 !mx-auto",
           content: "!flex-none",
           title: "!text-sm !font-medium !whitespace-nowrap",
           description: "!whitespace-nowrap",


### PR DESCRIPTION
## Why

`openinary-cloud` pins `patchedDependencies: "@openinary/ui@0.6.0"` and carries a `pnpm patch` against the published `dist/`. Any version bump invalidates that patch and the fixes inside it disappear with no error — which is about to happen, since #113 bumps the package.

The patch turned out to hold **six** hunks, not the three I first counted. Four are generic and belong here; two are cloud-specific and are staying downstream on purpose (see below).

## Upstreamed

**AssetPreview stuck on a grey square** — the real bug of the four. Loading state was reset in an effect keyed on `previewUrl`, but `usePreloadMedia` warms that same URL. On a revisit the `<img>` is served from cache and fires `load` *before* the passive effect runs; the effect then sets `isLoading` back to `true` with no load event left to clear it. The preview stays an empty skeleton until the sidebar is closed and reopened. State is now keyed by URL (`loadedUrl` / `failedUrl`), which cannot go stale in the first place, plus a `key={previewUrl}` on the `<img>` so the event is guaranteed to fire for the URL the state is keyed on.

**Folder upload accepted anything** — `webkitdirectory` ignores the input's `accept`, so `handleFolderSelect` took every file in the picked directory while the dropzone right above it filtered by `DEFAULT_ACCEPT`. One stray `.txt` or `.DS_Store` sibling and the API rejected the whole batch. It now runs the same `validateFile` check. Size is passed as `Infinity` — this component has no per-plan limit to check against, that stays the server's call.

**Toast drifting off-centre** — `!w-fit` drops the width sonner positions against, so the pill was laid out from the container's left edge and moved as its text changed length. `!inset-x-0 !mx-auto` pins it.

**Two cosmetics** — settings dialog to 600×750, and the empty state's trailing `ArrowUpRight` from `mr-2` to `ml-1` (it sits *after* the label, so a right margin was pushing from the wrong side).

## Deliberately left downstream

Two hunks are cloud-only and would break the self-hosted dashboard if upstreamed verbatim:

- the empty state's primary button becomes **Quick Start → `/get-started`**, a route that only exists in openinary-cloud
- the docs link points at **`docs.openinary.dev/cloud/overview`** rather than the docs root

If it's worth removing the patch entirely later, the clean seam is a prop on `MediaGrid` for the empty-state actions — it already takes `beamProps` for exactly this kind of host-app customisation. Out of scope here.

## Verification

`pnpm type-check`, `pnpm build` and `pnpm test` pass in `packages/ui`, and the emitted `dist/index.js` was checked to carry all five changes — the point of the exercise being that they survive the next publish.

Independent of #113: no overlapping files except a one-line className in `media-grid.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)