### PR TITLE
fix(core): keep URL-breaking characters out of storage keys

### DIFF
--- a/.changeset/loud-donkeys-repeat.md
+++ b/.changeset/loud-donkeys-repeat.md
@@ -1,0 +1,20 @@
+---
+"@openinary/core": minor
+---
+
+Keep characters that break a URL out of storage keys.
+
+Every asset is fetched through a URL built from its key, so a key holding a
+`#` or a `?` can never be delivered: the browser strips the fragment or query
+before the request leaves, and a video uploaded as `The #1 clip.mp4` is asked
+for as `The ` and 404s on a file that is sitting right there. A literal `%` is
+worse than truncation - readers decode, so `50%20off.mp4` is looked up as
+`50 off.mp4`.
+
+New `stripUrlHostile` export, applied on the way into storage: the upload and
+create-folder routes, plus rename and move. Spaces and accents are untouched;
+they encode and decode cleanly and always did.
+
+This only guards new writes. Assets already stored with one of these
+characters stay unreachable through a naively built URL until they are
+renamed.

--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -9,6 +9,7 @@ import {
   TRANSFORMATION_PRIORITY,
   TransformService,
   generateUploadSignature,
+  stripUrlHostile,
   validateUploadFileType,
   logger,
   serializeError,
@@ -184,7 +185,10 @@ export function createUploadRoute(deps: RouteDeps) {
   }
 
   /**
-   * Sanitizes file path to prevent directory traversal attacks
+   * Sanitizes file path to prevent directory traversal attacks, and strips
+   * the characters that would make the stored key unreachable through a URL
+   * (see stripUrlHostile). Both write routes below - file upload and folder
+   * creation - go through here, so nothing enters storage unaddressable.
    */
   function sanitizePath(filepath: string): string {
     // Remove leading slashes and any parent directory references
@@ -196,7 +200,7 @@ export function createUploadRoute(deps: RouteDeps) {
     // Remove any remaining dangerous patterns
     sanitized = sanitized.replace(/\/+/g, "/"); // Multiple slashes
 
-    return sanitized;
+    return stripUrlHostile(sanitized);
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,10 @@ export { getCachePath } from "./utils/cache";
 export { parseParams } from "./utils/parser";
 export { validateApiSecret } from "./utils/signature";
 export { generateUploadSignature, verifyUploadSignature } from "./utils/upload-signature";
-export { ALLOWED_UPLOAD_TYPES, validateUploadFileType } from "./utils/upload-validation";
+export {
+  ALLOWED_UPLOAD_TYPES,
+  stripUrlHostile,
+  validateUploadFileType,
+} from "./utils/upload-validation";
 export { deleteAssetCompletely, type DeleteAssetResult } from "./utils/asset-deletion";
 export { default as logger, serializeError } from "./utils/logger";

--- a/packages/core/src/routes/storage.ts
+++ b/packages/core/src/routes/storage.ts
@@ -5,6 +5,7 @@ import path from "path";
 import logger, { serializeError } from "../utils/logger";
 import { deleteAssetCompletely } from "../utils/asset-deletion";
 import { getUniqueFilePath } from "../utils/get-unique-file-path";
+import { stripUrlHostile } from "../utils/upload-validation";
 import { deleteCachedFiles, getCacheSize, clearAllCache } from "../utils/cache";
 import { sumTreeSize, type StorageNode } from "../utils/storage-tree";
 import {
@@ -700,7 +701,8 @@ export function createStorageRoute(deps: RouteDeps) {
       );
     }
 
-    const newName = typeof body.name === "string" ? body.name.trim() : "";
+    const newName =
+      typeof body.name === "string" ? stripUrlHostile(body.name.trim()) : "";
     if (!newName || newName.includes("/") || newName.includes("\\")) {
       return c.json(
         { error: "Bad request", message: "A valid name is required" },
@@ -813,7 +815,10 @@ export function createStorageRoute(deps: RouteDeps) {
         }
         targetDir =
           typeof body.destination === "string"
-            ? body.destination.trim().replace(/^\/+|\/+$/g, "")
+            ? stripUrlHostile(body.destination.trim()).replace(
+                /^\/+|\/+$/g,
+                "",
+              )
             : "";
 
         if (targetDir === normalizedDir) {

--- a/packages/core/src/utils/upload-validation.test.ts
+++ b/packages/core/src/utils/upload-validation.test.ts
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { stripUrlHostile } from './upload-validation';
+
+const BASE = 'https://cdn.example.com/t';
+
+// How a key is delivered: the client encodes per segment, the browser parses,
+// the transform route decodes per segment.
+function roundTrip(key: string): string {
+  const url = new URL(
+    `${BASE}/${key.split('/').map(encodeURIComponent).join('/')}`,
+  );
+  return url.pathname
+    .slice('/t/'.length)
+    .split('/')
+    .map(decodeURIComponent)
+    .join('/');
+}
+
+test('drops the characters that truncate a URL', () => {
+  // Reported by a user whose video would not play: the "#" ended the path,
+  // so the CDN was asked for "VAULT/The " and answered 404.
+  assert.equal(
+    stripUrlHostile('VAULT/The #1 clip.mp4'),
+    'VAULT/The 1 clip.mp4',
+  );
+  assert.equal(stripUrlHostile('what now?.png'), 'what now.png');
+});
+
+test('drops "%", which would round trip as a different key', () => {
+  // Readers decode, so a stored "50%20off.mp4" is looked up as "50 off.mp4".
+  assert.equal(stripUrlHostile('50%20off.mp4'), '5020off.mp4');
+});
+
+test('drops control characters', () => {
+  assert.equal(stripUrlHostile('a\u0000b\u001fc.png'), 'abc.png');
+});
+
+test('keeps everything a URL can carry', () => {
+  for (const name of [
+    'La Marée.png',
+    'clip [final].mp4',
+    "a+b & c's.jpg",
+    'Vidéos/Été 2026/plage.mov',
+    'nested/folder/photo.jpg',
+  ]) {
+    assert.equal(stripUrlHostile(name), name);
+  }
+});
+
+test('what it returns survives the delivery round trip', () => {
+  for (const raw of [
+    'VAULT/The #1 clip.mp4',
+    'OPTIMIZED/50% off? maybe.mp4',
+    'Vidéos/Été 2026/plage.mov',
+  ]) {
+    const key = stripUrlHostile(raw);
+    assert.equal(roundTrip(key), key);
+  }
+});
+
+test('the raw name does not - which is the bug', () => {
+  const url = new URL(`${BASE}/VAULT/The #1 clip.mp4`);
+  assert.notEqual(url.hash, '');
+  assert.equal(url.pathname.endsWith('.mp4'), false);
+});

--- a/packages/core/src/utils/upload-validation.ts
+++ b/packages/core/src/utils/upload-validation.ts
@@ -39,3 +39,37 @@ export function validateUploadFileType(
   }
   return allowedExtensions.includes(path.extname(filename).toLowerCase());
 }
+
+/**
+ * Characters that make a storage key unaddressable once it is part of a URL.
+ *
+ * Every asset is fetched through a URL built from its key, so a key holding
+ * one of these can never be delivered, however careful the client is:
+ *
+ * - `#` starts a fragment. The browser strips it and everything after it
+ *   before the request leaves, so `The #1 clip.mp4` is requested as `The `
+ *   and 404s on a file that is sitting right there.
+ * - `?` does the same as a query string.
+ * - `%` survives the round trip as a *different* key: readers decode, so
+ *   `50%20off.mp4` is looked up as `50 off.mp4`.
+ * - Control characters end up in the `Content-Disposition` and
+ *   `x-original-path` headers written from the key.
+ *
+ * Spaces and accents are deliberately kept - those encode and decode cleanly.
+ */
+const URL_HOSTILE_CHARS =
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: that is the point
+  /[#?%\u0000-\u001f]/g;
+
+/**
+ * Strips the characters above from a name or path on its way into storage.
+ *
+ * Applied at write time rather than encoded at read time on purpose: the
+ * readers are the dashboard, the SDKs and whatever URL a user hand-writes
+ * into their own `<img>` or `<video>`, and only the write side is ours to
+ * fix. Slashes pass through, so this is safe on a full path as well as on a
+ * single filename.
+ */
+export function stripUrlHostile(value: string): string {
+  return value.replace(URL_HOSTILE_CHARS, "");
+}


### PR DESCRIPTION
Completes the `#` fix. #113 stopped `@openinary/ui` from *building* broken URLs; this stops the broken keys from being created in the first place, which is the part that also covers the SDKs and the URLs users write by hand.

## The problem

An asset is only ever reachable through a URL built from its key, so some characters make a key permanently undeliverable no matter how careful the reader is:

| char | what happens |
|---|---|
| `#` | starts a fragment — the browser strips it *and everything after it* before the request leaves. `The #1 clip.mp4` is requested as `The ` and 404s. |
| `?` | same, as a query string. |
| `%` | survives as a *different* key: readers decode, so `50%20off.mp4` is looked up as `50 off.mp4`. |
| control chars | end up in the `Content-Disposition` and `x-original-path` headers written from the key. |

This is what a user hit: their video was fine in R2, listed fine in the dashboard, and would not play. No error anywhere — the request that reached the server was for a path that genuinely does not exist.

## Why the write side

Encoding at read time only fixes the readers we own. The readers are the dashboard, the SDKs, and whatever URL someone hand-writes into their own `<img>` or `<video>` — and that last one will never be fixed. One guard at the write boundary makes every reader correct, including the ones that don't exist yet.

`stripUrlHostile` lives next to `validateUploadFileType`, whose doc already states the intent: *"single source of truth for what Openinary accepts at upload time. Consumed by the OSS API and the SaaS so their whitelists cannot diverge."* Same job, same place.

Applied at all four write paths:

- `apps/api` upload and create-folder, via the existing `sanitizePath` both already route through
- `packages/core` storage route: rename (`PATCH`) and move destination (`POST`)

Spaces and accents pass through untouched — they encode and decode cleanly and always have. No key that works today changes.

## Trade-off worth naming

A filename is now silently altered on the way in: `The #1 clip.mp4` is stored as `The 1 clip.mp4`. That is the same call Cloudinary and the S3 key-naming guidance make, and the alternative is a file that only resolves through a fully-encoded URL that most of the ecosystem gets wrong. Rejecting the upload instead would be more honest but worse for the user, who has no idea why their filename is a problem.

**This only guards new writes.** Assets already stored with a `#` stay unreachable until renamed — renaming from the dashboard works and now strips the character.

## Verification

`packages/core`: `type-check` clean, 63 tests pass (6 new in `src/utils/upload-validation.test.ts`, pinning that a stripped key survives the encode/deliver/decode round trip and that the raw one does not), `build` clean and `stripUrlHostile` present in the emitted `dist`. `apps/api`: `type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)