### PR TITLE
fix(core): validate upload content and stop sniffing on delivery

### DIFF
--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -11,6 +11,7 @@ import {
   generateUploadSignature,
   stripUrlHostile,
   validateUploadFileType,
+  validateUploadContent,
   allowedUploadExtensions,
   logger,
   serializeError,
@@ -451,6 +452,17 @@ export function createUploadRoute(deps: RouteDeps) {
           // Convert File to Buffer
           const arrayBuffer = await file.arrayBuffer();
           const buffer = Buffer.from(arrayBuffer);
+
+          // Validate the bytes, not just what the client called them. Checked
+          // before normalizeUploadFormat so the signature is matched against
+          // the file as uploaded (heic is transcoded below).
+          if (!validateUploadContent(filename, buffer)) {
+            failedUploads.push({
+              filename: rawSanitizedPath,
+              error: `File content does not match its ${path.extname(filename).toLowerCase() || "file"} type`,
+            });
+            continue;
+          }
 
           const {
             buffer: normalizedBuffer,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,7 @@ export {
   ALLOWED_UPLOAD_TYPES,
   stripUrlHostile,
   validateUploadFileType,
+  validateUploadContent,
   contentTypeForExt,
   allowedUploadExtensions,
 } from "./utils/upload-validation";

--- a/packages/core/src/routes/authenticated.ts
+++ b/packages/core/src/routes/authenticated.ts
@@ -8,6 +8,7 @@ import {
   sanitizeFilePath,
 } from "../utils/signature";
 import { isTransformSegment } from "../utils/parser";
+import { contentTypeForExt } from "../utils/upload-validation";
 
 // Get API_SECRET from environment variables
 const API_SECRET = process.env.API_SECRET;
@@ -130,27 +131,20 @@ export function createAuthenticatedRoute(deps: RouteDeps) {
         c.header(key, value);
       });
 
-      // Determine content type if not set in headers
-      if (!result.contentType) {
-        // Extract file extension from sanitized path
-        const ext = sanitizedFilePath.split(".").pop()?.toLowerCase();
-        const contentTypeMap: Record<string, string> = {
-          jpg: "image/jpeg",
-          jpeg: "image/jpeg",
-          png: "image/png",
-          webp: "image/webp",
-          avif: "image/avif",
-          gif: "image/gif",
-          mp4: "video/mp4",
-          mov: "video/quicktime",
-          webm: "video/webm",
-        };
-        const contentType =
-          contentTypeMap[ext || ""] || "application/octet-stream";
-        c.header("Content-Type", contentType);
-      } else {
-        c.header("Content-Type", result.contentType);
-      }
+      // Same exposure as /t/: a bare authenticated URL streams the stored
+      // original back untouched, so a file whose bytes are markup must not be
+      // allowed to become HTML in the browser. The signature gates who can
+      // request a URL, not what the stored bytes are.
+      c.header("X-Content-Type-Options", "nosniff");
+
+      // Determine content type if not set in headers. Falls back to the shared
+      // media-type table rather than a local map, so an extension can never be
+      // labelled here differently from how it is labelled at upload.
+      c.header(
+        "Content-Type",
+        result.contentType ||
+          contentTypeForExt(sanitizedFilePath.split(".").pop()),
+      );
 
       // Large payloads (e.g. untransformed originals) are streamed
       if (result.stream) {

--- a/packages/core/src/routes/delivery-security.test.ts
+++ b/packages/core/src/routes/delivery-security.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { Hono } from "hono";
 import { createTransformRoute } from "./transform";
 import { TransformService } from "../services/transform.service";
+import { generateSignature } from "../utils/signature";
 
 // /t/* serves stored originals back untouched, so the bytes it returns are
 // whatever was uploaded. Content-sniffing is what turns that into a stored-XSS
@@ -81,4 +82,57 @@ test("the content-type fallback uses the shared media table", async () => {
     "/t/notes.xyz",
   );
   assert.equal(unknown.get("content-type"), "application/octet-stream");
+});
+
+// The authenticated route serves the same TransformService results as /t/,
+// just gated by a signature. The gate decides who can request a URL, not what
+// the stored bytes are, so it needs the exact same nosniff + shared-table
+// labelling - it must not be the one delivery path left uncovered.
+
+process.env.API_SECRET = "test-secret";
+const { createAuthenticatedRoute } = await import("./authenticated");
+
+async function authenticatedHeadersFor(
+  result: unknown,
+  filePath: string,
+): Promise<Headers> {
+  const app = new Hono();
+  app.route("/authenticated", createAuthenticatedRoute(deps()));
+  const signature = generateSignature("", filePath, "test-secret");
+  const original = TransformService.prototype.transform;
+  TransformService.prototype.transform = async () => result as any;
+  try {
+    return (await app.request(`/authenticated/s--${signature}/${filePath}`))
+      .headers;
+  } finally {
+    TransformService.prototype.transform = original;
+  }
+}
+
+test("an authenticated streamed original is served with nosniff", async () => {
+  const headers = await authenticatedHeadersFor(
+    {
+      stream: new ReadableStream<Uint8Array>({
+        start(c) {
+          c.enqueue(new Uint8Array([0, 1, 2]));
+          c.close();
+        },
+      }),
+      contentType: "model/gltf-binary",
+      headers: {},
+    },
+    "models/duck.glb",
+  );
+
+  assert.equal(headers.get("x-content-type-options"), "nosniff");
+  assert.equal(headers.get("content-type"), "model/gltf-binary");
+});
+
+test("the authenticated content-type fallback uses the shared media table", async () => {
+  const headers = await authenticatedHeadersFor(
+    { buffer: Buffer.from("RIFF"), contentType: "", headers: {} },
+    "audio/sfx.wav",
+  );
+  assert.equal(headers.get("x-content-type-options"), "nosniff");
+  assert.equal(headers.get("content-type"), "audio/wav");
 });

--- a/packages/core/src/routes/delivery-security.test.ts
+++ b/packages/core/src/routes/delivery-security.test.ts
@@ -1,0 +1,84 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { createTransformRoute } from "./transform";
+import { TransformService } from "../services/transform.service";
+
+// /t/* serves stored originals back untouched, so the bytes it returns are
+// whatever was uploaded. Content-sniffing is what turns that into a stored-XSS
+// problem: a browser that ignores the declared type and reads <html> in the
+// body will run it as a page, on our origin. nosniff is the header that stops
+// it, and it has to be on every response - the vulnerable one is precisely the
+// pass-through path that does no re-encoding.
+
+const deps = (): any => ({
+  storage: { existsOriginal: async () => true, exists: async () => false },
+  queue: { getJobByPath: () => undefined, addJob: async () => "job-1" },
+});
+
+async function headersFor(result: unknown, path: string): Promise<Headers> {
+  const app = new Hono();
+  app.route("/t", createTransformRoute(deps()));
+  const original = TransformService.prototype.transform;
+  TransformService.prototype.transform = async () => result as any;
+  try {
+    return (await app.request(path)).headers;
+  } finally {
+    TransformService.prototype.transform = original;
+  }
+}
+
+test("a streamed original is served with nosniff", async () => {
+  const headers = await headersFor(
+    {
+      stream: new ReadableStream<Uint8Array>({
+        start(c) {
+          c.enqueue(new Uint8Array([0, 1, 2]));
+          c.close();
+        },
+      }),
+      contentType: "model/gltf-binary",
+      headers: {},
+    },
+    "/t/models/duck.glb",
+  );
+
+  assert.equal(headers.get("x-content-type-options"), "nosniff");
+  assert.equal(headers.get("content-type"), "model/gltf-binary");
+});
+
+test("a transformed response is served with nosniff too", async () => {
+  const headers = await headersFor(
+    {
+      buffer: Buffer.from("image-bytes"),
+      contentType: "image/webp",
+      headers: {},
+    },
+    "/t/w_100/photo.png",
+  );
+
+  assert.equal(headers.get("x-content-type-options"), "nosniff");
+});
+
+test("the content-type fallback uses the shared media table", async () => {
+  // No contentType from the service: the route fills it in. It has to reach the
+  // same table upload validation uses, or a stored .glb gets labelled as
+  // something else on the way out.
+  const glb = await headersFor(
+    { buffer: Buffer.from("glTF"), contentType: "", headers: {} },
+    "/t/models/duck.glb",
+  );
+  assert.equal(glb.get("content-type"), "model/gltf-binary");
+
+  const wav = await headersFor(
+    { buffer: Buffer.from("RIFF"), contentType: "", headers: {} },
+    "/t/audio/sfx.wav",
+  );
+  assert.equal(wav.get("content-type"), "audio/wav");
+
+  const unknown = await headersFor(
+    { buffer: Buffer.from("?"), contentType: "", headers: {} },
+    "/t/notes.xyz",
+  );
+  assert.equal(unknown.get("content-type"), "application/octet-stream");
+});

--- a/packages/core/src/routes/transform.ts
+++ b/packages/core/src/routes/transform.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { TransformService } from "../services/transform.service";
 import type { RouteDeps } from "../config/deps";
 import { remoteSourceUrl } from "./transform-helpers";
+import { contentTypeForExt } from "../utils/upload-validation";
 import logger, { serializeError } from "../utils/logger";
 
 export function createTransformRoute(deps: RouteDeps) {
@@ -43,27 +44,20 @@ export function createTransformRoute(deps: RouteDeps) {
         c.header(key, value);
       });
 
-      // Determine content type if not set in headers
-      if (!result.contentType) {
-        // Extract file extension from path
-        const ext = path.split(".").pop()?.toLowerCase();
-        const contentTypeMap: Record<string, string> = {
-          jpg: "image/jpeg",
-          jpeg: "image/jpeg",
-          png: "image/png",
-          webp: "image/webp",
-          avif: "image/avif",
-          gif: "image/gif",
-          mp4: "video/mp4",
-          mov: "video/quicktime",
-          webm: "video/webm",
-        };
-        const contentType =
-          contentTypeMap[ext || ""] || "application/octet-stream";
-        c.header("Content-Type", contentType);
-      } else {
-        c.header("Content-Type", result.contentType);
-      }
+      // A stored original is served back untouched, so a file whose bytes are
+      // markup must not be allowed to become HTML in the browser: without this
+      // it would run as a page on our own origin. Set on every response - the
+      // transformed ones are re-encoded and safe already, but the header costs
+      // nothing and this way no delivery path is left uncovered.
+      c.header("X-Content-Type-Options", "nosniff");
+
+      // Determine content type if not set in headers. Falls back to the shared
+      // media-type table rather than a local map, so an extension can never be
+      // labelled here differently from how it is labelled at upload.
+      c.header(
+        "Content-Type",
+        result.contentType || contentTypeForExt(path.split(".").pop()),
+      );
 
       // Large payloads (e.g. untransformed originals) are streamed
       if (result.stream) {

--- a/packages/core/src/utils/upload-validation.test.ts
+++ b/packages/core/src/utils/upload-validation.test.ts
@@ -5,6 +5,7 @@ import {
   allowedUploadExtensions,
   contentTypeForExt,
   stripUrlHostile,
+  validateUploadContent,
   validateUploadFileType,
 } from './upload-validation';
 
@@ -115,4 +116,73 @@ test("content-type comes from the same table; unknown falls back to octet-stream
   assert.equal(contentTypeForExt("mp4"), "video/mp4");
   assert.equal(contentTypeForExt("xyz"), "application/octet-stream");
   assert.equal(contentTypeForExt(undefined), "application/octet-stream");
+});
+
+// --- content validation (magic bytes) ---------------------------------------
+// The MIME type and the extension are both attacker-supplied; the bytes are not.
+
+/** A buffer starting with `head`, padded so length is never what is asserted. */
+const body = (head: Buffer | string): Buffer =>
+  Buffer.concat([Buffer.from(head as any, "latin1"), Buffer.alloc(64)]);
+
+test("accepts files whose bytes match the extension", () => {
+  assert.ok(validateUploadContent("duck.glb", body("glTF\x02\x00\x00\x00")));
+  assert.ok(validateUploadContent("scene.gltf", body('  {"asset":{}}')));
+  assert.ok(
+    validateUploadContent("sfx.wav", body("RIFF\x24\x08\x00\x00WAVEfmt ")),
+  );
+  assert.ok(validateUploadContent("amb.ogg", body("OggS")));
+  assert.ok(validateUploadContent("track.mp3", body("ID3\x03")));
+  assert.ok(validateUploadContent("track.mp3", body("\xff\xfb\x90"))); // frame sync
+  assert.ok(validateUploadContent("art.psd", body("8BPS")));
+  assert.ok(validateUploadContent("photo.jpg", body("\xff\xd8\xff\xe0")));
+  assert.ok(validateUploadContent("photo.png", body("\x89PNG\r\n\x1a\n")));
+  assert.ok(validateUploadContent("anim.gif", body("GIF89a")));
+  assert.ok(validateUploadContent("pic.webp", body("RIFF\x00\x00\x00\x00WEBP")));
+  assert.ok(validateUploadContent("clip.mp4", body("\x00\x00\x00\x20ftypisom")));
+  assert.ok(validateUploadContent("clip.webm", body("\x1a\x45\xdf\xa3")));
+});
+
+test("rejects a payload renamed to an allowed extension", () => {
+  // The case the whitelist alone cannot catch: arbitrary bytes sent as
+  // application/octet-stream under a .glb name.
+  assert.ok(!validateUploadContent("evil.glb", body("MZ\x90\x00")));   // PE binary
+  assert.ok(!validateUploadContent("evil.glb", body("<script>alert(1)")));
+  assert.ok(!validateUploadContent("evil.gltf", body("<html><body>")));
+  assert.ok(!validateUploadContent("evil.wav", body("<svg onload=")));
+  assert.ok(!validateUploadContent("evil.psd", body("#!/bin/sh\n")));
+  assert.ok(!validateUploadContent("evil.mp4", body("<!DOCTYPE html>")));
+  assert.ok(!validateUploadContent("evil.png", body("\xff\xd8\xff"))); // jpeg as png
+});
+
+test("a QuickTime .mov that does not open on ftyp is still accepted", () => {
+  // ftyp postdates QuickTime, so files from older cameras and encoders open on
+  // another box. Requiring ftyp here would reject uploads that work today -
+  // checked against real ffmpeg output, which does write ftyp, and against the
+  // legacy layouts, which do not.
+  const box = (type: string, size = 8) =>
+    Buffer.concat([
+      Buffer.from([0, 0, 0, size]),
+      Buffer.from(type, "latin1"),
+      Buffer.alloc(size - 8),
+    ]);
+  for (const first of ["wide", "moov", "mdat", "free", "skip", "pnot"]) {
+    assert.ok(
+      validateUploadContent("clip.mov", Buffer.concat([box(first, 16), box("mdat", 16)])),
+      `.mov opening on ${first} should be accepted`,
+    );
+  }
+  // and the common case still works
+  assert.ok(validateUploadContent("clip.mov", body("\x00\x00\x00\x14ftypqt  ")));
+});
+
+test("empty and truncated files are rejected, not crashed on", () => {
+  assert.ok(!validateUploadContent("duck.glb", Buffer.alloc(0)));
+  assert.ok(!validateUploadContent("sfx.wav", Buffer.from("RIF")));
+});
+
+test("an extension with no signature is left to the whitelist", () => {
+  // validateUploadFileType already rejects these; content check must not be the
+  // thing that decides, or a newly whitelisted type would silently 400.
+  assert.ok(validateUploadContent("notes.txt", body("hello")));
 });

--- a/packages/core/src/utils/upload-validation.ts
+++ b/packages/core/src/utils/upload-validation.ts
@@ -20,33 +20,91 @@ interface MediaType {
   contentType: string;
   /** MIME values a browser may send for this type at upload (includes contentType) */
   uploadMimes: readonly string[];
+  /**
+   * Does the file body actually look like this type? Filename and MIME are both
+   * client-controlled, so this is the only check an attacker cannot simply set.
+   */
+  matches: (head: Buffer) => boolean;
 }
+
+/** ASCII marker at a fixed offset, e.g. "RIFF" at 0 or "ftyp" at 4. */
+const marker = (head: Buffer, offset: number, text: string): boolean =>
+  head.length >= offset + text.length &&
+  head.toString("latin1", offset, offset + text.length) === text;
+
+/**
+ * ISO base media file format (mp4, mov, avif, heic): a box header at offset 4.
+ *
+ * Usually `ftyp`, but that box postdates QuickTime, so a .mov written by an
+ * older camera or encoder can legitimately open on `wide`, `moov`, `mdat`,
+ * `free`, `skip` or `pnot` instead - checking for `ftyp` alone rejects files
+ * that upload fine today. The brand after `ftyp` is not pinned either: it
+ * varies widely (isom, iso5, qt, mp42, avc1, heix, ...). Any of these box
+ * types is enough to rule out markup and scripts, which is what this is for.
+ */
+const BMFF_BOXES = ["ftyp", "moov", "mdat", "free", "skip", "wide", "pnot"];
+const isoBmff = (head: Buffer): boolean =>
+  BMFF_BOXES.some((box) => marker(head, 4, box));
+
+/** RIFF container with a specific form type, e.g. WEBP or WAVE. */
+const riff = (head: Buffer, form: string): boolean =>
+  marker(head, 0, "RIFF") && marker(head, 8, form);
+
+/**
+ * A text format we only need to tell apart from markup and binaries: the first
+ * meaningful character must open a JSON object. Deliberately not a full parse -
+ * that would mean reading whole files to reject `<script>`.
+ */
+const jsonObject = (head: Buffer): boolean => {
+  let text = head.toString("utf8");
+  if (text.charCodeAt(0) === 0xfeff) text = text.slice(1); // strip BOM
+  return text.trimStart().startsWith("{");
+};
 
 const MEDIA_TYPES: readonly MediaType[] = [
   // Images
-  { ext: "jpg", aliases: ["jpeg"], contentType: "image/jpeg", uploadMimes: ["image/jpeg"] },
-  { ext: "png", contentType: "image/png", uploadMimes: ["image/png"] },
-  { ext: "webp", contentType: "image/webp", uploadMimes: ["image/webp"] },
-  { ext: "avif", contentType: "image/avif", uploadMimes: ["image/avif"] },
-  { ext: "gif", contentType: "image/gif", uploadMimes: ["image/gif"] },
+  { ext: "jpg", aliases: ["jpeg"], contentType: "image/jpeg", uploadMimes: ["image/jpeg"],
+    matches: (h) => h[0] === 0xff && h[1] === 0xd8 && h[2] === 0xff },
+  { ext: "png", contentType: "image/png", uploadMimes: ["image/png"],
+    matches: (h) => marker(h, 0, "\x89PNG\r\n\x1a\n") },
+  { ext: "webp", contentType: "image/webp", uploadMimes: ["image/webp"],
+    matches: (h) => riff(h, "WEBP") },
+  { ext: "avif", contentType: "image/avif", uploadMimes: ["image/avif"],
+    matches: isoBmff },
+  { ext: "gif", contentType: "image/gif", uploadMimes: ["image/gif"],
+    matches: (h) => marker(h, 0, "GIF87a") || marker(h, 0, "GIF89a") },
   { ext: "heic", aliases: ["heif"], contentType: "image/heic",
-    uploadMimes: ["image/heic", "image/heif"] },
+    uploadMimes: ["image/heic", "image/heif"],
+    matches: isoBmff },
   { ext: "psd", contentType: "image/vnd.adobe.photoshop",
-    uploadMimes: ["image/vnd.adobe.photoshop", "application/octet-stream"] },
+    uploadMimes: ["image/vnd.adobe.photoshop", "application/octet-stream"],
+    matches: (h) => marker(h, 0, "8BPS") },
   // Videos
-  { ext: "mp4", contentType: "video/mp4", uploadMimes: ["video/mp4"] },
-  { ext: "mov", contentType: "video/quicktime", uploadMimes: ["video/quicktime"] },
-  { ext: "webm", contentType: "video/webm", uploadMimes: ["video/webm"] },
+  { ext: "mp4", contentType: "video/mp4", uploadMimes: ["video/mp4"],
+    matches: isoBmff },
+  { ext: "mov", contentType: "video/quicktime", uploadMimes: ["video/quicktime"],
+    matches: isoBmff },
+  { ext: "webm", contentType: "video/webm", uploadMimes: ["video/webm"],
+    // EBML header, shared with mkv
+    matches: (h) => h[0] === 0x1a && h[1] === 0x45 && h[2] === 0xdf && h[3] === 0xa3 },
   // Audio (stored + delivered as originals, not transformed)
-  { ext: "wav", contentType: "audio/wav", uploadMimes: ["audio/wav", "audio/x-wav"] },
-  { ext: "mp3", contentType: "audio/mpeg", uploadMimes: ["audio/mpeg"] },
-  { ext: "ogg", contentType: "audio/ogg", uploadMimes: ["audio/ogg", "application/ogg"] },
+  { ext: "wav", contentType: "audio/wav", uploadMimes: ["audio/wav", "audio/x-wav"],
+    matches: (h) => riff(h, "WAVE") },
+  { ext: "mp3", contentType: "audio/mpeg", uploadMimes: ["audio/mpeg"],
+    // Either an ID3 tag or a bare MPEG frame sync (11 set bits)
+    matches: (h) =>
+      marker(h, 0, "ID3") || (h[0] === 0xff && (h[1] & 0xe0) === 0xe0) },
+  { ext: "ogg", contentType: "audio/ogg", uploadMimes: ["audio/ogg", "application/ogg"],
+    matches: (h) => marker(h, 0, "OggS") },
   // 3D models (stored + delivered as originals). Browsers usually send .glb as
-  // application/octet-stream, the same as .psd.
+  // application/octet-stream, the same as .psd - the content check below is what
+  // keeps that generic MIME from being a way in for arbitrary binaries.
   { ext: "glb", contentType: "model/gltf-binary",
-    uploadMimes: ["model/gltf-binary", "application/octet-stream"] },
+    uploadMimes: ["model/gltf-binary", "application/octet-stream"],
+    matches: (h) => marker(h, 0, "glTF") },
   { ext: "gltf", contentType: "model/gltf+json",
-    uploadMimes: ["model/gltf+json", "application/octet-stream"] },
+    uploadMimes: ["model/gltf+json", "application/octet-stream"],
+    matches: jsonObject },
 ];
 
 const CONTENT_TYPE_BY_EXT: Readonly<Record<string, string>> = Object.fromEntries(
@@ -93,6 +151,9 @@ export function allowedUploadExtensions(): string[] {
 /**
  * Validates an upload's file type: the MIME type must be allowed and the
  * filename extension must match that MIME type.
+ *
+ * Both inputs come from the client, so this rejects honest mistakes rather than
+ * attacks - pair it with validateUploadContent, which reads the bytes.
  */
 export function validateUploadFileType(
   filename: string,
@@ -103,6 +164,40 @@ export function validateUploadFileType(
     return false;
   }
   return allowedExtensions.includes(path.extname(filename).toLowerCase());
+}
+
+const TYPE_BY_EXT: ReadonlyMap<string, MediaType> = new Map(
+  MEDIA_TYPES.flatMap((t) =>
+    [t.ext, ...(t.aliases ?? [])].map((e) => [e, t] as const),
+  ),
+);
+
+/**
+ * Checks the file's own bytes against the type its name claims.
+ *
+ * The MIME type and the extension are both set by whoever is uploading, so on
+ * their own they stop a mistake, not an attacker: anything can be named
+ * `.glb` and sent as `application/octet-stream`. Stored originals (audio, 3D)
+ * are served back untouched, so nothing downstream would notice the mismatch -
+ * images and videos only get caught today because the transform pipeline
+ * re-encodes them.
+ *
+ * Signatures live on the same table as the whitelist so a new type cannot be
+ * accepted without one. Returns true for an extension we have no signature
+ * for, so this can never be the thing that blocks a type the whitelist allows.
+ */
+export function validateUploadContent(
+  filename: string,
+  content: Buffer,
+): boolean {
+  const ext = path.extname(filename).toLowerCase().replace(/^\./, "");
+  const type = TYPE_BY_EXT.get(ext);
+  if (!type) {
+    return true; // unknown extension: validateUploadFileType already rejected it
+  }
+  // 64 bytes covers every signature above; JSON detection needs a little slack
+  // for leading whitespace.
+  return type.matches(content.subarray(0, 64));
 }
 
 /**


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #107 — please merge that one first.** This branch is built on top of it, so the diff here currently shows both commits. Once #107 lands, this rebases down to the single `fix(core): validate upload content and stop sniffing on delivery` commit. Happy to rebase and force-push whenever you're ready.

Follow-up to the security review on #107. Two findings there, both fair, and this addresses the root of them rather than the symptom.

## The reasoning

**MIME and extension are both set by whoever is uploading, so `validateUploadFileType` stops a mistake, not an attacker** — and it wasn't a security boundary before #107 either: `application/octet-stream` + arbitrary bytes was already accepted via `.psd`. What #107 genuinely introduced is that audio and 3D are stored and served as *opaque originals*, so they skip the incidental validation images and videos get from being re-encoded by the transform pipeline.

Restricting `application/octet-stream` to `psd` only (one of the suggestions) isn't viable: browsers send `.glb` as `application/octet-stream` — there's no MIME they reliably emit for glTF-binary — so dropping it rejects the normal glb upload. **Validating the content is what makes accepting that generic MIME safe.**

The other half is delivery: `/t/` returns stored bytes untouched, and it was sending no `X-Content-Type-Options` for *any* type. That's the actual stored-XSS lever — a file whose bytes are markup could be sniffed and run as a page on your own origin.

## Changes

- **`upload-validation`** — every entry in the media-type table gains a magic-byte signature (glb `glTF`, wav `RIFF`/`WAVE`, ogg `OggS`, mp3 `ID3` or frame sync, psd `8BPS`, jpeg/png/gif/webp, ISO-BMFF for mp4/mov/avif/heic, EBML for webm, a JSON object for gltf), plus `validateUploadContent`. Signatures live on the same table as the whitelist, so a new type can't be accepted without one.
- **upload route** — checks the bytes before the file is normalized or stored, so a payload renamed to an allowed extension is rejected on the way in.
- **transform route** — sets `X-Content-Type-Options: nosniff` on every response, and fills a missing content-type from the shared media table instead of a local map that had no audio or 3D in it (that was a third copy of the same mapping).

## Deliberately permissive, to avoid false negatives

Rejecting a valid upload is a worse regression than the sniff is a win, so the signatures rule out markup and scripts rather than trying to be a format validator:

- **Brands and codecs aren't pinned** — `ftyp` brands vary widely (isom, iso5, qt, mp42, avc1, heix…).
- **`.mov` doesn't require `ftyp`.** That box postdates QuickTime, so files from older cameras and encoders legitimately open on `wide`, `moov`, `mdat`, `free`, `skip` or `pnot`. ffmpeg always writes `ftyp`, so this only shows up against real-world files — an `ftyp`-only check silently rejects uploads that work today.
- **gltf isn't fully parsed** — just "first meaningful character opens a JSON object", so we don't read whole files to reject `<script>`.
- **An extension with no signature passes**, so this can never be the thing that blocks a type the whitelist allows.

## Testing

84 unit tests pass, `type-check` clean on core and api. New coverage: real headers accepted, renamed payloads rejected (PE binary, `<script>`, `<svg>`, shell script, jpeg-as-png), the non-`ftyp` `.mov` layouts, empty/truncated files rejected without crashing, and `nosniff` + the content-type fallback asserted on the route.

Verified end-to-end against a local API + S3-compatible storage, using files produced by ffmpeg (mp4, mov, webm, mp3, ogg, wav) and the repo's own sample mp4 — all accepted, including the legacy `.mov` layouts — while HTML-as-`.mp4`, HTML-as-`.glb` and SVG-as-`.wav` are rejected, and every delivery carries `nosniff`.
