### PR TITLE
Return 400 for transform params on a non-transformable type

### DIFF
--- a/packages/core/src/routes/transform.ts
+++ b/packages/core/src/routes/transform.ts
@@ -69,6 +69,10 @@ export function createTransformRoute(deps: RouteDeps) {
         return c.body(new Uint8Array(result.buffer!), 202);
       }
 
+      // Transform params requested on a type that can't be transformed
+      if (result.status === 400) {
+        return c.text(result.buffer!.toString(), 400);
+      }
       // Check if this is an error response
       if (
         result.contentType === "text/plain" &&

--- a/packages/core/src/services/transform.service.test.ts
+++ b/packages/core/src/services/transform.service.test.ts
@@ -152,3 +152,17 @@ test("a bare audio/3D URL streams the original with its real content-type", asyn
   assert.ok(wav.stream, "wav original should be streamed");
   assert.equal(wav.contentType, "audio/wav");
 });
+
+test("transform params on a non-transformable type 400 instead of serving or erroring", async () => {
+  const service = new TransformService(fakeStorage(), fakeQueue());
+
+  const result = await service.transform({
+    path: "/t/w_500/audio/sfx.wav",
+    userAgent: "",
+    context: {} as any,
+  });
+
+  assert.equal(result.status, 400);
+  assert.equal(result.stream, undefined, "must not fall back to the original");
+  assert.match(result.buffer!.toString(), /audio\/sfx\.wav/);
+});

--- a/packages/core/src/services/transform.service.ts
+++ b/packages/core/src/services/transform.service.ts
@@ -313,7 +313,34 @@ export class TransformService {
       );
     }
 
-    // Prepare source file
+    const isTransformableImage = !!ext?.match(/jpe?g|png|webp|avif|gif|psd/);
+
+    // Reached only when effectiveParams is non-empty - the bare-URL case
+    // short-circuits to streamOriginal above. A transform was requested on a
+    // type nothing here knows how to transform (audio, 3D, or any other
+    // stored-original type, e.g. /t/w_500/doc.pdf). Reject before staging the
+    // source file rather than downloading it only to throw the params away:
+    // silently dropping the params and serving the original would also hide
+    // a bug in whatever built this URL, so this fails loud and points at the
+    // URL that actually works.
+    if (!isTransformableImage && !isVideo(ext)) {
+      const message =
+        (ext ? "." + ext : "This file type") +
+        " can't be transformed. Request /t/" +
+        filePath +
+        " for the original.";
+      return {
+        buffer: Buffer.from(message),
+        contentType: "text/plain",
+        status: 400,
+        headers: {
+          "Content-Length": Buffer.byteLength(message).toString(),
+          "Cache-Control": "no-store",
+        },
+      };
+    }
+
+// Prepare source file
     const sourcePath = await prepareSourceFile(
       this.storage,
       filePath,
@@ -330,8 +357,10 @@ export class TransformService {
       let contentType: string;
       let optimizationResult: any;
 
-      // Process based on file type
-      if (ext?.match(/jpe?g|png|webp|avif|gif|psd/)) {
+      // Process based on file type. isTransformableImage / isVideo(ext) are
+      // the only two possibilities here: anything else already returned a
+      // 400 above, before this file was staged.
+      if (isTransformableImage) {
         const result = await this.processImageFile(
           sourcePath,
           effectiveParams,
@@ -341,7 +370,7 @@ export class TransformService {
         buffer = result.buffer;
         contentType = result.contentType;
         optimizationResult = result.optimizationResult;
-      } else if (isVideo(ext)) {
+      } else {
         // Only thumbnail requests reach this point (non-thumbnail video
         // transformations are intercepted before prepareSourceFile above);
         // thumbnails are extracted synchronously like images
@@ -354,8 +383,6 @@ export class TransformService {
             "Cache-Control": "public, max-age=31536000, must-revalidate",
           },
         };
-      } else {
-        throw new Error("Unsupported file type");
       }
 
       // Save to caches


### PR DESCRIPTION
Follow-up to #106. That PR added a passthrough content-type map for unsupported formats, but #107 and #116 already cover that case: upload-validation.ts is now the single source of truth for the upload whitelist and the delivery content-type, and a bare /t/<path> streams any stored original with its real content-type.

The gap left over is params on a type nothing here can transform, for example /t/w_500/doc.pdf. That fell through to a generic catch-all and came back as an unlabeled 500. This returns a 400 instead, before the source file is staged, with a message pointing at the bare /t/<path> URL that actually works.

svg stays excluded, unrelated to this change.