### PR TITLE
Give the deploy task the credentials wrangler reads

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -27,7 +27,14 @@
     },
     "deploy": {
       "cache": false,
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      // turbo 2 runs tasks in strict env mode: a task only sees the variables
+      // declared for it. wrangler reads its credentials from the environment,
+      // so without this it is handed none and fails as if the secret were
+      // missing - which is how the first deploy-marketing run on main died.
+      // passThroughEnv rather than env: these reach the task without entering
+      // the cache hash, which is what a credential wants.
+      "passThroughEnv": ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"]
     },
     "lint": {
       "outputs": []


### PR DESCRIPTION
The first `deploy-marketing` run on `main` after the monorepo merge [failed](https://github.com/openinary/openinary/actions/runs/31486608937):

```
ERROR  In a non-interactive environment, it's necessary to set a
       CLOUDFLARE_API_TOKEN environment variable for wrangler to work.
Failed: marketing#deploy
```

The secret is defined in this repository and the workflow step exports it. turbo is what removes it.

## Cause

turbo 2 defaults to `envMode: "strict"` — a task's process only receives the variables declared for that task. The `deploy` task declared none:

```json
"deploy": {
  "cache": false,
  "dependsOn": ["^build"]
}
```

so both credentials were stripped before `marketing#deploy` ran, and wrangler saw an empty environment.

It surfaces now because deploying no longer happens inside the app. It goes through the root `deploy:marketing` script, which puts turbo between the workflow and wrangler where nothing sat before.

## Fix

`passThroughEnv` rather than `env`, so a credential reaches the task without entering a cache key. The same declaration covers `deploy:cloud`, `deploy:admin` and `deploy:telemetry`, which route through this task too.

## Verified

`turbo run deploy --filter=marketing --dry=json`, before and after:

| | `envMode` | `specified.passThroughEnv` | resolved passthrough |
|---|---|---|---|
| before | `strict` | `null` | — |
| after | `strict` | `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN` | both, when set in the environment |

No deploy was run to check this — the real proof is the next `deploy-marketing`, which can be started from the Actions tab (`workflow_dispatch`) without waiting for a marketing change.

openinary.dev was never down: the failed run never replaced the Worker, so the previous deployment kept serving.