### PR TITLE
chore: add FUNDING.yml (GitHub Sponsors + Ko-fi)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: openinary
+ko_fi: openinary


### PR DESCRIPTION
Adds the sponsor button to the repo, pointing to https://github.com/sponsors/openinary and https://ko-fi.com/openinary.