### PR TITLE
Fix the marketing deploy: build the registry in prebuild instead of copying the deleted root /r

### DIFF
--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack --port 3200",
     "lint": "eslint .",
-    "prebuild": "mkdir -p public/r && cp ../../r/*.json public/r/",
+    "prebuild": "pnpm --filter registry run registry:build",
     "build": "next build --webpack",
     "start": "next start",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",


### PR DESCRIPTION
## What

One line in `apps/marketing/package.json`:

```diff
-    "prebuild": "mkdir -p public/r && cp ../../r/*.json public/r/",
+    "prebuild": "pnpm --filter registry run registry:build",
```

## Why

#127 deleted the root `/r` folder, but the branch was merged without the follow-up commit that unhooked marketing's `prebuild` from it, so `deploy-marketing` on main now fails at `cp: cannot stat '../../r/*.json'` (run 31494159090's predecessor, same error as before the merge).

`packages/registry`'s `registry:build` already outputs to `apps/marketing/public/r` since #127, so the prebuild can just build from source. `public/r` stays gitignored: nothing committed, and the served files are regenerated on every deploy so they can never go stale.

## Verified

Locally, from a clean state (`rm -rf apps/marketing/public/r`): `pnpm build` regenerates `public/r/{registry,file-uploader,upload-token}.json` and the Next build completes.