### PR TITLE
Drop the registry stale-check, the built output is no longer committed

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -54,12 +54,7 @@ jobs:
       - name: Test the upload signature the registry helper depends on
         run: pnpm --filter @openinary/core test
 
-      - name: Rebuild registry
+      # The output is not committed: marketing's prebuild regenerates public/r
+      # on every build, so this only proves the registry builds from source.
+      - name: Build registry
         run: pnpm --filter registry registry:build
-
-      - name: Fail if built registry (apps/marketing/public/r) is stale
-        run: |
-          if ! git diff --exit-code -- apps/marketing/public/r/; then
-            echo "::error::The built registry in apps/marketing/public/r is out of date. Run 'pnpm --filter registry registry:build' and commit the result."
-            exit 1
-          fi

--- a/packages/registry/README.md
+++ b/packages/registry/README.md
@@ -47,5 +47,6 @@ pnpm --filter registry registry:build # rebuild apps/marketing/public/r from reg
 - `src/stubs/`, type-check-only stand-ins for the consumer's shadcn components;
   **not** part of the registry output.
 
-After changing any source file, rebuild and commit `apps/marketing/public/r`,
-CI fails if it is stale.
+The built output is not committed: `apps/marketing`'s `prebuild` runs
+`registry:build`, so `public/r` is regenerated from source on every build
+and deploy.


### PR DESCRIPTION
Follow-up to #128. `apps/marketing/public/r` is gitignored and regenerated from source by marketing's `prebuild`, so the workflow's `git diff` stale-check can never fail: it diffs an ignored path. Freshness is guaranteed by construction now.

- `registry.yml`: the stale-check step is removed; the build step stays as a smoke test that `shadcn build` succeeds from source (renamed "Build registry", with a comment saying why there is nothing to diff).
- `packages/registry/README.md`: the "rebuild and commit, CI fails if stale" instruction is replaced by the actual flow (nothing committed, prebuild regenerates `public/r` on every build and deploy).

Cherry-pick of `9624471` from the #128 branch, which was not part of that squash.