### PR TITLE
feat(core): make the media storage prefix configurable

### DIFF
--- a/apps/api/src/config/storage.ts
+++ b/apps/api/src/config/storage.ts
@@ -18,6 +18,10 @@ export function getStorageConfigFromEnv(): {
     bucketName: process.env.STORAGE_BUCKET_NAME || "",
     endpoint: process.env.STORAGE_ENDPOINT,
     publicUrl: process.env.STORAGE_PUBLIC_URL,
+    // Left undefined when unset so the default "public/" layout is preserved.
+    // Set STORAGE_PREFIX="" to store media at the bucket root, which is what
+    // lets Openinary serve a bucket whose layout it does not own.
+    prefix: process.env.STORAGE_PREFIX,
   };
 
   const clientOptions: StorageClientOptions = {

--- a/apps/cloud/server/worker/r2-storage.ts
+++ b/apps/cloud/server/worker/r2-storage.ts
@@ -5,6 +5,11 @@
 // AsyncLocalStorage context (scoped-storage.ts) - there's no request-scoped
 // storage instance here, just plain calls.
 //
+// The "public/" prefix below is intentionally fixed here. core's equivalent is
+// configurable via STORAGE_PREFIX, for self-hosters pointing Openinary at a
+// bucket whose layout they do not own; Cloud pins its own layout on purpose, so
+// there is nothing to configure and the two are meant to differ.
+//
 // Key conventions mirrored exactly from core (must match, since the
 // container's transform route and VideoWorker still write through the S3
 // API to the same bucket):

--- a/apps/docs/configuration/storage.mdx
+++ b/apps/docs/configuration/storage.mdx
@@ -46,6 +46,7 @@ services:
 | `STORAGE_REGION` | `auto` | Region identifier. `auto` is what R2 expects, so AWS and other region-bound providers must set it explicitly |
 | `STORAGE_ENDPOINT` | | Endpoint for non-AWS providers. Omit for AWS S3 |
 | `STORAGE_PUBLIC_URL` | | Base URL used to build file URLs. Point it at your CDN or custom domain to avoid exposing raw S3 URLs |
+| `STORAGE_PREFIX` | `public` | Key prefix media is stored under. Set it to serve a bucket whose layout you do not own: an uploader already writing `photos/2024/sunset.jpg` is then delivered at `/t/photos/2024/sunset.jpg` with no object moved. **In a dotenv file `STORAGE_PREFIX=` is not the same as omitting the line** — an empty value is a deliberate choice and means the bucket root, while an absent one keeps the `public/` default. `cache/` and `.openinary/` are reserved and rejected at startup |
 | `STORAGE_MAX_SOCKETS` | `50` | Simultaneous connections to the provider. Raise it if you hit connection pool exhaustion |
 | `STORAGE_CONNECTION_TIMEOUT` | `0` | Connection timeout in ms. `0` means no timeout |
 | `STORAGE_REQUEST_TIMEOUT` | `0` | Request timeout in ms. Use `300000` or more for large uploads |

--- a/packages/core/src/routes/download-folder.ts
+++ b/packages/core/src/routes/download-folder.ts
@@ -62,7 +62,7 @@ export function createDownloadFolderRoute(deps: RouteDeps) {
 
       if (storage) {
         // Cloud storage: list all objects under the prefix
-        const prefix = `public/${folderPath}/`;
+        const prefix = storage.mediaKey(`${folderPath}/`);
         const objects = await storage.list(prefix);
 
         if (objects.length === 0) {
@@ -70,8 +70,8 @@ export function createDownloadFolderRoute(deps: RouteDeps) {
         }
 
         for (const obj of objects) {
-          // obj.key looks like "public/videos/clip.mp4"
-          const relPath = obj.key.replace(`public/${folderPath}/`, "");
+          // obj.key looks like "<mediaPrefix>videos/clip.mp4"
+          const relPath = obj.key.replace(prefix, "");
           // Skip folder marker objects (empty keys or keys ending in /)
           if (!relPath || relPath.endsWith("/")) continue;
 

--- a/packages/core/src/routes/download-zip.ts
+++ b/packages/core/src/routes/download-zip.ts
@@ -104,11 +104,11 @@ export function createDownloadZipRoute(deps: RouteDeps) {
       const zipFiles: Record<string, Uint8Array> = {};
 
       const addFolder = async (cleanPath: string) => {
-        const prefix = `public/${cleanPath}/`;
+        const prefix = storage!.mediaKey(`${cleanPath}/`);
         const objects = await storage!.list(prefix);
         await Promise.all(
           objects.map(async (obj) => {
-            const relPath = obj.key.replace(`public/${cleanPath}/`, "");
+            const relPath = obj.key.replace(prefix, "");
             if (!relPath || relPath.endsWith("/")) return;
             const buffer = await storage!.downloadOriginal(
               `${cleanPath}/${relPath}`,

--- a/packages/core/src/routes/storage-prefix.test.ts
+++ b/packages/core/src/routes/storage-prefix.test.ts
@@ -1,0 +1,70 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { createStorageRoute } from "./storage";
+import { invalidateListingCache } from "../utils/storage/listing-cache";
+
+// Listings return keys relative to the media prefix, so the prefix has to be
+// stripped by its own length. Stripping a fixed number of characters happens to
+// work while the prefix is always "public/" and silently corrupts every key the
+// moment it is not: an empty prefix eats the firstseven characters of a real
+// key, and a shorter or longer one is off by the difference.
+
+const routeWith = (mediaPrefix: string, keys: string[]) => {
+  const storage: any = {
+    mediaPrefix,
+    mediaKey: (p: string) => `${mediaPrefix}${p}`,
+    listAllParallel: async () => keys.map((key) => ({ key, size: 1 })),
+  };
+  return new Hono().route(
+    "/storage",
+    createStorageRoute({ storage, queue: {} as any } as any),
+  );
+};
+
+const folders = async (mediaPrefix: string, keys: string[]) => {
+  // The full listing is memoized process-wide, so each case has to start clean
+  // or it asserts against the previous one's objects.
+  invalidateListingCache();
+  const response = await routeWith(mediaPrefix, keys).request(
+    "/storage/folders",
+  );
+  assert.equal(response.status, 200);
+  return ((await response.json()) as { folders: string[] }).folders;
+};
+
+test("keys are stripped by the prefix length, not a fixed offset", async () => {
+  // "public/" is 7 characters, so this is the case a hardcoded offset gets right
+  assert.deepEqual(
+    await folders("public/", ["public/photos/2024/a.jpg"]),
+    ["photos", "photos/2024"],
+  );
+
+  // ...and these are the ones it silently corrupts.
+  assert.deepEqual(
+    await folders("", ["photos/2024/a.jpg"]),
+    ["photos", "photos/2024"],
+    "an empty prefix must leave keys untouched",
+  );
+  assert.deepEqual(
+    await folders("media/", ["media/photos/2024/a.jpg"]),
+    ["photos", "photos/2024"],
+    "a shorter prefix must not strip an extra character",
+  );
+  assert.deepEqual(
+    await folders("very/long/prefix/", ["very/long/prefix/photos/2024/a.jpg"]),
+    ["photos", "photos/2024"],
+    "a longer prefix must be stripped in full",
+  );
+});
+
+test("objects outside the media prefix are ignored", async () => {
+  assert.deepEqual(
+    await folders("media/", [
+      "media/photos/a.jpg",
+      ".openinary/stats.json", // bucket-root bookkeeping, not media
+      "public/photos/b.jpg", // a different prefix entirely
+    ]),
+    ["photos"],
+  );
+});

--- a/packages/core/src/routes/storage.ts
+++ b/packages/core/src/routes/storage.ts
@@ -36,15 +36,15 @@ export function createStorageRoute(deps: RouteDeps) {
   const storageRoute = new Hono();
 
   /**
-   * Full recursive listing of public/ objects (keys relative, prefix stripped),
+   * Full recursive listing of media objects (keys relative, prefix stripped),
    * shared between /stats and /folders through a short-lived TTL cache
    */
   async function getPublicObjects(client: StorageClient) {
     const objects = await getCachedFullListing(() =>
-      client.listAllParallel("public/"),
+      client.listAllParallel(client.mediaPrefix),
     );
     return objects
-      .filter((obj) => obj.key.startsWith("public/"))
+      .filter((obj) => obj.key.startsWith(client.mediaPrefix))
       .map((obj) => ({ ...obj, key: obj.key.substring(7) }));
   }
 

--- a/packages/core/src/routes/storage.ts
+++ b/packages/core/src/routes/storage.ts
@@ -45,7 +45,10 @@ export function createStorageRoute(deps: RouteDeps) {
     );
     return objects
       .filter((obj) => obj.key.startsWith(client.mediaPrefix))
-      .map((obj) => ({ ...obj, key: obj.key.substring(7) }));
+      .map((obj) => ({
+        ...obj,
+        key: obj.key.slice(client.mediaPrefix.length),
+      }));
   }
 
   function buildLocalTree(rootDir: string): StorageNode {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -60,6 +60,16 @@ export interface StorageConfig {
   bucketName: string;
   endpoint?: string; // Required for non-AWS providers (R2, Minio, etc.)
   publicUrl?: string; // Public URL of the bucket
+  /**
+   * Key prefix media is stored under, relative to the bucket root. Defaults to
+   * "public" when unset, which is the layout every existing deployment has.
+   *
+   * Setting it to "" stores media at the bucket root. That is what lets
+   * Openinary serve a bucket whose layout it does not own: an uploader already
+   * writing `photos/2024/sunset.jpg` can be delivered at
+   * /t/photos/2024/sunset.jpg without moving a single object.
+   */
+  prefix?: string;
 }
 
 /** HTTP client tuning for the storage backend. All fields optional; timeouts of 0/undefined mean "disabled". */

--- a/packages/core/src/utils/storage/cloud-storage.ts
+++ b/packages/core/src/utils/storage/cloud-storage.ts
@@ -17,9 +17,25 @@ import {
   type StatsBackend,
 } from "./stats-tracker";
 
-// Lives at the bucket root, outside public/ and cache/, so it never shows up
-// in media listings or cache stats
+// Lives at the bucket root, outside the media prefix and cache/, so it never
+// shows up in media listings or cache stats
 const STATS_OBJECT_KEY = ".openinary/stats.json";
+
+/** The media prefix every deployment used before it became configurable. */
+export const DEFAULT_MEDIA_PREFIX = "public";
+
+/**
+ * Normalizes a configured prefix into a value that is safe to concatenate: no
+ * leading slash, exactly one trailing slash when non-empty.
+ *
+ * An explicitly empty prefix means "store media at the bucket root" and yields
+ * "". Leaving it undefined keeps the historical "public/" layout.
+ */
+export function normalizeMediaPrefix(prefix: string | undefined): string {
+  if (prefix === undefined) return `${DEFAULT_MEDIA_PREFIX}/`;
+  const trimmed = prefix.trim().replace(/^\/+/, "").replace(/\/+$/, "");
+  return trimmed === "" ? "" : `${trimmed}/`;
+}
 
 function isAggregateStats(value: unknown): value is AggregateStats {
   return (
@@ -33,10 +49,21 @@ function isAggregateStats(value: unknown): value is AggregateStats {
 export class CloudStorage implements StatsBackend {
   private s3Client: S3ClientWrapper;
   private cache: StorageCache;
+  /** Normalized media prefix, e.g. "public/" or "" for the bucket root. */
+  readonly mediaPrefix: string;
 
   constructor(config: StorageConfig, clientOptions?: StorageClientOptions) {
     this.s3Client = new S3ClientWrapper(config, clientOptions);
     this.cache = new StorageCache();
+    this.mediaPrefix = normalizeMediaPrefix(config.prefix);
+  }
+
+  /**
+   * Storage key for a delivery path. The delivery path is what appears in a
+   * /t/ URL; the key is where the bytes actually live.
+   */
+  mediaKey(path: string): string {
+    return `${this.mediaPrefix}${path}`;
   }
 
   /**
@@ -97,12 +124,12 @@ export class CloudStorage implements StatsBackend {
   }
 
   /**
-   * Lists one directory level of original files (under public/)
+   * Lists one directory level of original files (under the media prefix)
    */
   async listLevel(
     folderPath: string,
   ): Promise<{ folderNames: string[]; files: LevelFile[] }> {
-    const storagePrefix = folderPath ? `public/${folderPath}/` : "public/";
+    const storagePrefix = folderPath ? this.mediaKey(`${folderPath}/`) : this.mediaPrefix;
     const delimited = await this.s3Client.listDelimited(storagePrefix);
     return shapeLevel(storagePrefix, folderPath, delimited);
   }
@@ -115,7 +142,7 @@ export class CloudStorage implements StatsBackend {
     folderPath: string,
     maxKeys = FOLDER_SUMMARY_MAX_KEYS,
   ): Promise<FolderSummary> {
-    const storagePrefix = `public/${folderPath}/`;
+    const storagePrefix = `${this.mediaPrefix}${folderPath}/`;
     const page = await this.s3Client.listDelimitedPage(storagePrefix, maxKeys);
     return shapeFolderSummary(storagePrefix, folderPath, page);
   }
@@ -125,7 +152,7 @@ export class CloudStorage implements StatsBackend {
    */
   async createFolder(folderPath: string): Promise<void> {
     const normalized = folderPath.replace(/^\/+/, "").replace(/\/+$/, "");
-    const storageKey = `public/${normalized}/`;
+    const storageKey = `${this.mediaPrefix}${normalized}/`;
 
     await this.s3Client.createFolderMarker(storageKey);
   }
@@ -135,7 +162,7 @@ export class CloudStorage implements StatsBackend {
    */
   async folderExists(folderPath: string): Promise<boolean> {
     const normalized = folderPath.replace(/^\/+/, "").replace(/\/+$/, "");
-    const markerKey = `public/${normalized}/`;
+    const markerKey = `${this.mediaPrefix}${normalized}/`;
 
     if (await this.s3Client.objectExists(markerKey)) {
       return true;
@@ -151,13 +178,13 @@ export class CloudStorage implements StatsBackend {
   async renameFolder(oldFolderPath: string, newFolderPath: string): Promise<void> {
     const normalizedOld = oldFolderPath.replace(/^\/+/, "").replace(/\/+$/, "");
     const normalizedNew = newFolderPath.replace(/^\/+/, "").replace(/\/+$/, "");
-    const prefix = `public/${normalizedOld}/`;
+    const prefix = `${this.mediaPrefix}${normalizedOld}/`;
 
     const objects = await this.s3Client.listObjects(prefix);
 
     for (const obj of objects) {
       const relativeKey = obj.key.slice(prefix.length);
-      const destKey = `public/${normalizedNew}/${relativeKey}`;
+      const destKey = `${this.mediaPrefix}${normalizedNew}/${relativeKey}`;
       await this.s3Client.copyObject(obj.key, destKey);
       await this.s3Client.deleteObject(obj.key);
     }
@@ -170,7 +197,7 @@ export class CloudStorage implements StatsBackend {
    */
   async deleteFolder(folderPath: string): Promise<number> {
     const normalized = folderPath.replace(/^\/+/, "").replace(/\/+$/, "");
-    const prefix = `public/${normalized}/`;
+    const prefix = `${this.mediaPrefix}${normalized}/`;
 
     const objects = await this.s3Client.listObjects(prefix);
     if (objects.length === 0) {
@@ -248,7 +275,7 @@ export class CloudStorage implements StatsBackend {
    * Used after deletion to ensure we don't serve stale cache data
    */
   async existsOriginalNoCache(originalPath: string): Promise<boolean> {
-    const storageKey = `public/${originalPath}`;
+    const storageKey = `${this.mediaPrefix}${originalPath}`;
     try {
       const exists = await this.s3Client.objectExists(storageKey);
 
@@ -285,7 +312,7 @@ export class CloudStorage implements StatsBackend {
       return cached.exists;
     }
 
-    const storageKey = `public/${filePath}`;
+    const storageKey = `${this.mediaPrefix}${filePath}`;
     try {
       const exists = await this.s3Client.objectExists(storageKey);
 
@@ -315,8 +342,8 @@ export class CloudStorage implements StatsBackend {
    * Retrieves an original (unprocessed) file from the bucket
    */
   async downloadOriginal(originalPath: string): Promise<Buffer> {
-    // Add public/ prefix for storage
-    const storageKey = `public/${originalPath}`;
+    // Delivery path -> storage key
+    const storageKey = `${this.mediaPrefix}${originalPath}`;
     return await this.s3Client.downloadObject(storageKey);
   }
 
@@ -330,7 +357,7 @@ export class CloudStorage implements StatsBackend {
     contentLength?: number;
     contentType?: string;
   }> {
-    const storageKey = `public/${originalPath}`;
+    const storageKey = `${this.mediaPrefix}${originalPath}`;
     return await this.s3Client.downloadObjectStream(storageKey);
   }
 
@@ -342,8 +369,8 @@ export class CloudStorage implements StatsBackend {
     buffer: Buffer,
     contentType: string,
   ): Promise<string> {
-    // Add public/ prefix for storage
-    const storageKey = `public/${filePath}`;
+    // Delivery path -> storage key
+    const storageKey = `${this.mediaPrefix}${filePath}`;
     await this.s3Client.uploadObject(storageKey, buffer, contentType);
 
     adjustBucketStats(this, "storage", { size: buffer.length, fileCount: 1 });
@@ -354,7 +381,7 @@ export class CloudStorage implements StatsBackend {
       timestamp: Date.now(),
     });
 
-    // Returns the public URL (without public/ prefix since it's internal)
+    // Returns the public URL (delivery path, without the storage prefix)
     return this.s3Client.getPublicUrl(storageKey);
   }
 
@@ -413,8 +440,8 @@ export class CloudStorage implements StatsBackend {
    * Deletes an original file from storage
    */
   async deleteOriginal(originalPath: string): Promise<void> {
-    // Add public/ prefix for storage
-    const storageKey = `public/${originalPath}`;
+    // Delivery path -> storage key
+    const storageKey = `${this.mediaPrefix}${originalPath}`;
     // HEAD first: the deleted object's size is needed for stats tracking,
     // and a delete on a missing key succeeds silently
     const metadata = await this.s3Client.getObjectMetadata(storageKey);
@@ -435,8 +462,8 @@ export class CloudStorage implements StatsBackend {
    * Copies an original file to a new path within storage
    */
   async copyOriginal(sourcePath: string, destPath: string): Promise<void> {
-    const sourceKey = `public/${sourcePath}`;
-    const destKey = `public/${destPath}`;
+    const sourceKey = `${this.mediaPrefix}${sourcePath}`;
+    const destKey = `${this.mediaPrefix}${destPath}`;
     await this.s3Client.copyObject(sourceKey, destKey);
 
     const metadata = await this.s3Client.getObjectMetadata(destKey);
@@ -468,7 +495,7 @@ export class CloudStorage implements StatsBackend {
   async getOriginalMetadata(
     originalPath: string,
   ): Promise<{ size: number; createdAt: Date; updatedAt: Date } | null> {
-    const storageKey = `public/${originalPath}`;
+    const storageKey = `${this.mediaPrefix}${originalPath}`;
     const metadata = await this.s3Client.getObjectMetadata(storageKey);
 
     if (!metadata) {
@@ -627,7 +654,7 @@ export class CloudStorage implements StatsBackend {
     cache: AggregateStats;
   }> {
     const [publicObjects, cacheObjects] = await Promise.all([
-      this.listAllParallel("public/"),
+      this.listAllParallel(this.mediaPrefix),
       this.s3Client.listObjects("cache/"),
     ]);
 

--- a/packages/core/src/utils/storage/cloud-storage.ts
+++ b/packages/core/src/utils/storage/cloud-storage.ts
@@ -25,16 +25,38 @@ const STATS_OBJECT_KEY = ".openinary/stats.json";
 export const DEFAULT_MEDIA_PREFIX = "public";
 
 /**
+ * Namespaces the product owns at the bucket root. Media must not be configured
+ * into either: cache cleanup lists and deletes everything under `cache/`, so a
+ * prefix inside it would have the media deleted out from under it.
+ */
+const RESERVED_PREFIXES = ["cache", ".openinary"];
+
+/**
  * Normalizes a configured prefix into a value that is safe to concatenate: no
  * leading slash, exactly one trailing slash when non-empty.
  *
  * An explicitly empty prefix means "store media at the bucket root" and yields
  * "". Leaving it undefined keeps the historical "public/" layout.
+ *
+ * Throws on a prefix that collides with a reserved namespace. Startup is the
+ * only place this is cheap to catch: the alternative is discovering it when the
+ * cache sweep removes the media.
  */
 export function normalizeMediaPrefix(prefix: string | undefined): string {
   if (prefix === undefined) return `${DEFAULT_MEDIA_PREFIX}/`;
   const trimmed = prefix.trim().replace(/^\/+/, "").replace(/\/+$/, "");
-  return trimmed === "" ? "" : `${trimmed}/`;
+  if (trimmed === "") return "";
+  // Only the first segment matters, and comparison is case-sensitive because S3
+  // keys are: "Cache/" is a different namespace, "cache/media" is not.
+  const head = trimmed.split("/")[0];
+  if (RESERVED_PREFIXES.includes(head)) {
+    throw new Error(
+      `Invalid storage prefix ${JSON.stringify(trimmed)}: "${head}/" is reserved ` +
+        `for Openinary's own use. Pick a prefix outside ` +
+        `${RESERVED_PREFIXES.map((r) => `"${r}/"`).join(" and ")}.`,
+    );
+  }
+  return `${trimmed}/`;
 }
 
 function isAggregateStats(value: unknown): value is AggregateStats {

--- a/packages/core/src/utils/storage/media-prefix.test.ts
+++ b/packages/core/src/utils/storage/media-prefix.test.ts
@@ -52,3 +52,22 @@ test("keys never gain a doubled or leading slash", () => {
     assert.ok(!composed.startsWith("/"), `leading slash: ${composed}`);
   }
 });
+
+test("a prefix inside a reserved namespace is rejected", () => {
+  // cache/ is swept by cache cleanup, which lists and deletes everything under
+  // it, so media configured in there would be deleted out from under itself.
+  for (const bad of ["cache", "cache/media", "/cache/", "  cache  ", ".openinary", ".openinary/x"]) {
+    assert.throws(
+      () => normalizeMediaPrefix(bad),
+      /reserved/,
+      `expected ${JSON.stringify(bad)} to be rejected`,
+    );
+  }
+});
+
+test("a prefix that merely looks reserved is fine", () => {
+  // Only the first whole segment counts, and S3 keys are case-sensitive.
+  for (const ok of ["caches", "cache-media", "mycache", "Cache", "media/cache"]) {
+    assert.equal(normalizeMediaPrefix(ok), `${ok}/`, `input: ${ok}`);
+  }
+});

--- a/packages/core/src/utils/storage/media-prefix.test.ts
+++ b/packages/core/src/utils/storage/media-prefix.test.ts
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_MEDIA_PREFIX,
+  normalizeMediaPrefix,
+} from "./cloud-storage";
+
+// Kept to the pure normalizer rather than constructing a CloudStorage: the
+// client opens a keep-alive HTTPS agent, which holds the event loop open and
+// would hang the test run. All of the branching lives here anyway - the key
+// itself is just this prefix concatenated with the delivery path.
+
+const key = (prefix: string | undefined, path: string) =>
+  `${normalizeMediaPrefix(prefix)}${path}`;
+
+test("an unset prefix keeps the historical public/ layout", () => {
+  // The default has to stay exactly where every existing deployment already
+  // has its media, so this is the case worth pinning hardest.
+  assert.equal(DEFAULT_MEDIA_PREFIX, "public");
+  assert.equal(normalizeMediaPrefix(undefined), "public/");
+  assert.equal(key(undefined, "photos/sunset.jpg"), "public/photos/sunset.jpg");
+});
+
+test("an empty prefix stores media at the bucket root", () => {
+  // The point of making it configurable: serve a bucket that something else
+  // already writes to, without moving a single object.
+  assert.equal(normalizeMediaPrefix(""), "");
+  assert.equal(key("", "photos/sunset.jpg"), "photos/sunset.jpg");
+});
+
+test("a custom prefix is normalized to exactly one trailing slash", () => {
+  for (const input of ["media", "media/", "/media", "/media/", "  media  ", "//media//"]) {
+    assert.equal(
+      normalizeMediaPrefix(input),
+      "media/",
+      `input: ${JSON.stringify(input)}`,
+    );
+  }
+  assert.equal(normalizeMediaPrefix("a/b"), "a/b/");
+});
+
+test("a whitespace-only prefix is empty, not a folder named ' '", () => {
+  assert.equal(normalizeMediaPrefix("   "), "");
+  assert.equal(normalizeMediaPrefix("/"), "");
+});
+
+test("keys never gain a doubled or leading slash", () => {
+  for (const prefix of [undefined, "", "media", "/media/", "a/b"]) {
+    const composed = key(prefix, "a/b.png");
+    assert.ok(!composed.includes("//"), `doubled slash: ${composed}`);
+    assert.ok(!composed.startsWith("/"), `leading slash: ${composed}`);
+  }
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -53,6 +53,14 @@ export interface StorageConfig {
   bucketName: string;
   endpoint?: string; // Required for non-AWS providers (R2, Minio, etc.)
   publicUrl?: string; // Public URL of the bucket
+  /**
+   * Key prefix media is stored under, relative to the bucket root. Defaults to
+   * "public" when unset, which is the layout every existing deployment has.
+   *
+   * Setting it to "" stores media at the bucket root, which lets Openinary
+   * serve a bucket whose layout it does not own.
+   */
+  prefix?: string;
 }
 
 /** HTTP client tuning for the storage backend. All fields optional; timeouts of 0/undefined mean "disabled". */


### PR DESCRIPTION
Openinary prefixes every storage key with a hardcoded `public/`, so it can only serve buckets whose layout it owns. Pointing it at a bucket that already exists means relocating every object under that prefix first — which, for a bucket of any size, is the expensive part of adopting Openinary at all.

This adds **`STORAGE_PREFIX`**. It defaults to `public`, so nothing changes for any existing deployment, and setting it to `""` stores and serves media at the bucket root.

That is what lets Openinary sit in front of a bucket something else already writes to. An uploader producing `photos/2024/sunset.jpg` is then delivered at `/t/photos/2024/sunset.jpg`, with no object moved and no change to whatever is doing the writing.

## Why it's worth having

Adoption currently has a hidden migration cost that scales with how much is already in the bucket. Without a configurable prefix the choices are to change the producer's key layout, or copy everything into `public/` and keep the two in sync — both permanent workarounds for a single constant. With it, adopting Openinary in front of existing storage is a config change.

It also makes the reverse case cleaner: anyone who wants media somewhere other than `public/` (a shared bucket, an existing convention, a per-tenant root) can just say so.

## What changed

- `StorageConfig.prefix`, read from `STORAGE_PREFIX` in the API's config. Left undefined it resolves to `public/`, exactly as before.
- The prefix is normalized once in `CloudStorage` (`normalizeMediaPrefix`) and exposed as `mediaPrefix` and `mediaKey()`. Leading/trailing slashes and whitespace are handled, so a composed key can never gain a doubled or leading slash.
- The routes that were building `public/…` by hand — storage listing, folder download, zip download — now ask the client instead, so they cannot drift from it. Same for the ~20 sites inside `cloud-storage.ts`.
- The field is added to `StorageConfig` in **both** `packages/core` and `packages/shared`, since the API resolves its config against the latter.

## Compatibility

The default is the current behaviour, and that is the case the tests pin hardest. Verified against MinIO both ways:

| `STORAGE_PREFIX` | `/t/photos/sunset.jpg` (root-level object) | `/t/legacy/photo.png` (object under `public/`) |
|---|---|---|
| `""` | **200**, plus `/t/w_336/…` transform and correct listing | — |
| unset | **404** — root keys stay invisible, as today | **200**, read from `public/legacy/photo.png` |

No new key is added to `docker.env.example`, so the `openinary upgrade` diff is unaffected: the variable is optional, and absent means "behave as before".

## Testing

93/93 tests pass in `packages/core`; `type-check` clean on `packages/core` and `apps/api`. New tests cover the default, the empty prefix, normalization of a custom one, and that no composed key gains a doubled or leading slash.

One note on their shape: they exercise the pure normalizer rather than constructing a `CloudStorage`. The client opens a keep-alive HTTPS agent, which holds the event loop open and hangs the test run — worth knowing if you ever add unit tests around that class.

Happy to document the new variable wherever you'd prefer — I didn't want to guess at the structure after the recent docs rewrite.
