### PR TITLE
docs(api-reference): default the base URL to Cloud

### DIFF
--- a/apps/docs/api-reference/api-keys/create.mdx
+++ b/apps/docs/api-reference/api-keys/create.mdx
@@ -8,7 +8,7 @@ description: "Generate a new API key for authenticating requests"
 Post to `/api-keys/create` and the response carries the full key. That is the only time you see it, so store it immediately.
 
 ```bash
-curl -X POST http://localhost:3000/api-keys/create \
+curl -X POST https://media.example.com/api-keys/create \
   -H "Authorization: Bearer <api_key>" \
   -H "Content-Type: application/json" \
   -d '{"name": "production", "expiresIn": 31536000}'

--- a/apps/docs/api-reference/api-keys/delete.mdx
+++ b/apps/docs/api-reference/api-keys/delete.mdx
@@ -8,7 +8,7 @@ description: "Permanently revoke an API key"
 Deletes a key by its ID. This is irreversible, and any service using that key loses access immediately. To block access temporarily instead, [update the key](/api-reference/api-keys/update) with `"enabled": false`.
 
 ```bash
-curl -X DELETE http://localhost:3000/api-keys/key_abc123 \
+curl -X DELETE https://media.example.com/api-keys/key_abc123 \
   -H "Authorization: Bearer <api_key>"
 ```
 

--- a/apps/docs/api-reference/api-keys/list.mdx
+++ b/apps/docs/api-reference/api-keys/list.mdx
@@ -8,7 +8,7 @@ description: "Retrieve every API key on the account"
 Returns every key on the account, without the secret values. Use `id` for update and delete calls.
 
 ```bash
-curl http://localhost:3000/api-keys/list \
+curl https://media.example.com/api-keys/list \
   -H "Authorization: Bearer <api_key>"
 ```
 

--- a/apps/docs/api-reference/api-keys/update.mdx
+++ b/apps/docs/api-reference/api-keys/update.mdx
@@ -8,7 +8,7 @@ description: "Rename or enable/disable an existing API key"
 Patch a key by its ID to rename it, or to disable it without deleting it. Send only the fields you want to change.
 
 ```bash
-curl -X PATCH http://localhost:3000/api-keys/key_abc123 \
+curl -X PATCH https://media.example.com/api-keys/key_abc123 \
   -H "Authorization: Bearer <api_key>" \
   -H "Content-Type: application/json" \
   -d '{"name": "production-v2"}'
@@ -33,7 +33,7 @@ Get `keyId` from [List API Keys](/api-reference/api-keys/list).
 ## Disable a key
 
 ```bash
-curl -X PATCH http://localhost:3000/api-keys/key_abc123 \
+curl -X PATCH https://media.example.com/api-keys/key_abc123 \
   -H "Authorization: Bearer <api_key>" \
   -H "Content-Type: application/json" \
   -d '{"enabled": false}'

--- a/apps/docs/api-reference/cache/invalidate.mdx
+++ b/apps/docs/api-reference/cache/invalidate.mdx
@@ -12,7 +12,7 @@ DELETE /invalidate/{path}
 ```
 
 ```bash
-curl -X DELETE http://localhost:3000/invalidate/photos/portrait.jpg \
+curl -X DELETE https://media.example.com/invalidate/photos/portrait.jpg \
   -H "Authorization: Bearer <api_key>"
 ```
 
@@ -60,7 +60,7 @@ POST /storage/cache/clear
 ```
 
 ```bash
-curl -X POST http://localhost:3000/storage/cache/clear \
+curl -X POST https://cdn.openinary.dev/storage/cache/clear \
   -H "Authorization: Bearer <api_key>"
 ```
 

--- a/apps/docs/api-reference/files/create-folder.mdx
+++ b/apps/docs/api-reference/files/create-folder.mdx
@@ -10,7 +10,7 @@ POST /upload/createfolder
 ```
 
 ```bash
-curl -X POST http://localhost:3000/upload/createfolder \
+curl -X POST https://cdn.openinary.dev/upload/createfolder \
   -H "Authorization: Bearer <api_key>" \
   -F "folder=products/2024"
 ```

--- a/apps/docs/api-reference/files/download-folder.mdx
+++ b/apps/docs/api-reference/files/download-folder.mdx
@@ -12,7 +12,7 @@ GET /download-folder/{path}
 ```
 
 ```bash
-curl -O -J http://localhost:3000/download-folder/photos
+curl -O -J https://media.example.com/download-folder/photos
 ```
 
 **Auth:** Public (rate limited)

--- a/apps/docs/api-reference/files/download-zip.mdx
+++ b/apps/docs/api-reference/files/download-zip.mdx
@@ -12,7 +12,7 @@ POST /download-zip
 ```
 
 ```bash
-curl -X POST http://localhost:3000/download-zip \
+curl -X POST https://media.example.com/download-zip \
   -H "Authorization: Bearer <api_key>" \
   -H "Content-Type: application/json" \
   -d '{"items": [{"path": "photos/portrait.jpg", "kind": "file"}, {"path": "videos", "kind": "folder"}]}' \

--- a/apps/docs/api-reference/files/download.mdx
+++ b/apps/docs/api-reference/files/download.mdx
@@ -10,10 +10,11 @@ GET /download/{path}
 ```
 
 ```bash
-curl -O -J http://localhost:3000/download/photos/portrait.jpg
+curl -O -J https://cdn.openinary.dev/download/photos/portrait.jpg \
+  -H "Authorization: Bearer <api_key>"
 ```
 
-**Auth:** Public (rate limited)
+**Auth:** API key on Cloud, public and rate limited self-hosted. Drop the header when you call your own instance.
 
 ## Path parameters
 

--- a/apps/docs/api-reference/files/upload-sign.mdx
+++ b/apps/docs/api-reference/files/upload-sign.mdx
@@ -10,7 +10,7 @@ POST /upload/sign
 ```
 
 ```bash
-curl -X POST http://localhost:3000/upload/sign \
+curl -X POST https://cdn.openinary.dev/upload/sign \
   -H "Authorization: Bearer <api_key>" \
   -H "Content-Type: application/json" \
   -d '{"folder": "photos", "expiresIn": 300}'

--- a/apps/docs/api-reference/files/upload.mdx
+++ b/apps/docs/api-reference/files/upload.mdx
@@ -10,7 +10,7 @@ POST /upload
 ```
 
 ```bash
-curl -X POST http://localhost:3000/upload \
+curl -X POST https://cdn.openinary.dev/upload \
   -H "Authorization: Bearer <api_key>" \
   -F "files=@photo.jpg"
 ```
@@ -48,7 +48,7 @@ HEIC and HEIF files are transcoded to JPEG on upload. The returned `filename`, `
 <Tab title="Upload to folder">
 
 ```bash
-curl -X POST http://localhost:3000/upload \
+curl -X POST https://cdn.openinary.dev/upload \
   -H "Authorization: Bearer <api_key>" \
   -F "files=@photo.jpg" \
   -F "folder=products/2024"
@@ -59,7 +59,7 @@ curl -X POST http://localhost:3000/upload \
 <Tab title="Upload with prewarm">
 
 ```bash
-curl -X POST http://localhost:3000/upload \
+curl -X POST https://media.example.com/upload \
   -H "Authorization: Bearer <api_key>" \
   -F "files=@photo.jpg" \
   -F "folder=photos" \
@@ -67,14 +67,14 @@ curl -X POST http://localhost:3000/upload \
   -F "transformations=w_400,h_400,c_fill,g_face"
 ```
 
-Uploads the file and immediately generates two cached variants.
+Uploads the file and immediately generates two cached variants. Self-hosted only: Cloud accepts the field and ignores it.
 
 </Tab>
 
 <Tab title="Multiple files with custom names">
 
 ```bash
-curl -X POST http://localhost:3000/upload \
+curl -X POST https://cdn.openinary.dev/upload \
   -H "Authorization: Bearer <api_key>" \
   -F "files=@IMG_001.jpg" \
   -F "files=@IMG_002.jpg" \
@@ -111,6 +111,8 @@ A fully successful upload returns only `success` and `files`. There is no `error
 }
 ```
 
+That is the self-hosted shape. On Cloud the `url` carries the bucket prefix, `/b/{bucketId}/t/photos/photo.jpg`, and `prewarmedUrls` is absent: variants are generated on the first request instead.
+
 | Field     | Type      | Description                                                                                         |
 | --------- | --------- | --------------------------------------------------------------------------------------------------- |
 | `success` | `boolean` | `true` if at least one file was processed. Still `true` on a `207`, so check `errors` for partial failure |
@@ -124,7 +126,7 @@ Each entry in `files`:
 | `filename`                 | `string`   | Original or custom filename. A HEIC or HEIF upload comes back with a `.jpg` extension       |
 | `path`                     | `string`   | Storage path relative to root                                                              |
 | `size`                     | `number`   | File size in bytes, after any conversion                                                   |
-| `url`                      | `string`   | Root-relative delivery path, always starting with `/t/`. Prefix your instance origin for an absolute URL |
+| `url`                      | `string`   | Root-relative delivery path. Self-hosted it starts with `/t/`, on Cloud with `/b/{bucketId}/t/`. Prefix your base URL for an absolute URL |
 | `prewarmedUrls`            | `string[]` | Image transformation paths generated and cached during the upload. Omitted when empty      |
 | `prewarmErrors`            | `string[]` | Prewarm failures. The file still uploaded successfully. Omitted when empty                 |
 | `queuedTransformationUrls` | `string[]` | Video transformation paths queued for background processing. Omitted when empty            |

--- a/apps/docs/api-reference/health.mdx
+++ b/apps/docs/api-reference/health.mdx
@@ -8,7 +8,7 @@ description: "Check server and database availability"
 Two probes. `GET /health` is a public liveness check, `GET /health/database` needs an API key and reports on the SQLite file.
 
 ```bash
-curl http://localhost:3000/health
+curl https://media.example.com/health
 ```
 
 ## Server health
@@ -38,7 +38,7 @@ GET /health/database
 ```
 
 ```bash
-curl http://localhost:3000/health/database \
+curl https://media.example.com/health/database \
   -H "Authorization: Bearer <api_key>"
 ```
 

--- a/apps/docs/api-reference/introduction.mdx
+++ b/apps/docs/api-reference/introduction.mdx
@@ -1,18 +1,31 @@
 ---
 title: "API Reference"
-description: "Base URL, authentication, rate limits and every endpoint of a self-hosted Openinary instance"
+description: "Base URL, authentication, rate limits and every endpoint, documented once for Cloud and self-hosted"
 ---
 
-Everything is relative to your instance URL, and protected endpoints take an API key as a Bearer token.
+Every path below is relative to your base URL, and protected endpoints take an API key as a Bearer token.
 
 ```http
-GET http://localhost:3000/storage
+GET https://cdn.openinary.dev/storage
 Authorization: Bearer <your_api_key>
 ```
 
-Create keys from the dashboard at `/api-keys` or through the [API Keys API](/api-reference/api-keys/create). In API-only mode the first key is printed to the server logs at startup. Every API-key endpoint also accepts a dashboard session cookie, which is how the dashboard calls storage and upload without minting a key for itself.
+## Base URL
 
-**These endpoints work on both Cloud and self-hosted**, with the same request and response shapes. The pages that do not are marked **Self-hosted only** at the top. On Cloud the delivery URL carries a bucket prefix and keys travel as `x-api-key` or `Authorization`, see [what differs on Cloud](/cloud/api).
+| Running on | Base URL |
+| --- | --- |
+| Cloud | `https://cdn.openinary.dev` |
+| Self-hosted | your instance origin, e.g. `https://media.example.com`, or `http://localhost:3000` in development |
+
+Examples on these pages use the Cloud host. Self-hosted, swap the origin and every request is otherwise identical. Delivery is the one path that differs: on Cloud it carries a bucket prefix, `/b/{bucketId}/t/...`, see [your base URL](/media-transformations/overview#your-base-url).
+
+## Authentication
+
+On Cloud, create keys in the dashboard at [app.openinary.dev](https://app.openinary.dev) under **Settings → API keys**. A key is shown once and is pinned to a single bucket, which is why no endpoint takes a bucket ID. Either header works, `Authorization: Bearer` or `x-api-key`.
+
+Self-hosted, create them from the dashboard at `/api-keys` or through the [API Keys API](/api-reference/api-keys/create). In API-only mode the first key is printed to the server logs at startup. Every API-key endpoint also accepts a dashboard session cookie, which is how the dashboard calls storage and upload without minting a key for itself.
+
+**These endpoints work on both Cloud and self-hosted**, with the same request and response shapes. The pages that do not are marked **Self-hosted only** at the top and use `https://media.example.com` in their examples. For the full list of what Cloud does not have, see [what differs on Cloud](/cloud/api).
 
 ## Endpoints
 
@@ -23,7 +36,7 @@ Create keys from the dashboard at `/api-keys` or through the [API Keys API](/api
 | **Files** | `POST /upload` | API key or presigned |
 | | `POST /upload/sign` | API key |
 | | `POST /upload/createfolder` | API key |
-| | `GET /download/{path}` | Public |
+| | `GET /download/{path}` | Public self-hosted, API key on Cloud |
 | | `GET /download-folder/{path}` | Public |
 | | `POST /download-zip` | API key |
 | **Storage** | `GET /storage` | API key |
@@ -38,15 +51,15 @@ Create keys from the dashboard at `/api-keys` or through the [API Keys API](/api
 | | `DELETE /storage/{path}` | API key |
 | **Cache** | `DELETE /invalidate/{path}` | API key |
 | | `POST /storage/cache/clear` | API key |
-| **Video** | `GET /video-status/{transformations}/{path}` | Public |
-| | `GET /video-status/{transformations}/{path}/size` | Public |
+| **Video** | `GET /video-status/{transformations}/{path}` | Public self-hosted, API key on Cloud |
+| | `GET /video-status/{transformations}/{path}/size` | Public self-hosted, API key on Cloud |
 | **Queue** | `GET /queue/stats` | API key |
 | | `GET /queue/worker/stats` | API key |
 | | `GET /queue/jobs` | API key |
 | | `POST /queue/jobs/{jobId}/retry` | API key |
 | | `POST /queue/jobs/{jobId}/cancel` | API key |
 | | `DELETE /queue/jobs/{jobId}` | API key |
-| | `GET /queue/events` | Public |
+| | `GET /queue/events` | Public self-hosted, API key on Cloud |
 | **API Keys** | `POST /api-keys/create` | API key or session |
 | | `GET /api-keys/list` | API key or session |
 | | `PATCH /api-keys/{keyId}` | API key or session |
@@ -59,6 +72,8 @@ Create keys from the dashboard at `/api-keys` or through the [API Keys API](/api
 Public routes are limited by IP: 100 requests per 60 seconds, tunable with `PUBLIC_RATE_LIMIT_MAX` and `PUBLIC_RATE_LIMIT_WINDOW_MS`. Every response carries `X-RateLimit-Limit`, `X-RateLimit-Remaining` and `X-RateLimit-Reset`.
 
 Most API-key endpoints sit outside that limiter, but `POST /upload` and `GET /health/database` do not, so a burst of uploads can be throttled even with a valid key.
+
+Those numbers are self-hosted. Cloud limits delivery only, 300 requests per 60 seconds per IP and 1,000 per account, and leaves upload, signing and storage calls unlimited. See [Cloud rate limits](/cloud/api#rate-limits).
 
 ## Errors
 

--- a/apps/docs/api-reference/queue/events.mdx
+++ b/apps/docs/api-reference/queue/events.mdx
@@ -6,7 +6,9 @@ description: "Stream video processing job updates over Server-Sent Events"
 Open a persistent connection and job lifecycle events arrive as they happen. Use it for live progress in your UI instead of polling.
 
 ```javascript
-const source = new EventSource("http://localhost:3000/queue/events");
+// Cloud authenticates this stream, so proxy it from your server: EventSource
+// cannot send an Authorization header, and a key does not belong in a bundle.
+const source = new EventSource("/api/openinary/queue/events");
 
 source.addEventListener("job:progress", (e) => {
   const { jobId, progress } = JSON.parse(e.data);
@@ -28,9 +30,9 @@ source.addEventListener("job:error", (e) => {
 GET /queue/events
 ```
 
-**Auth:** Public (rate limited)
+**Auth:** API key on Cloud, public and rate limited self-hosted.
 
-Read the raw stream with `curl -N http://localhost:3000/queue/events`.
+Read the raw stream with `curl -N https://cdn.openinary.dev/queue/events -H "Authorization: Bearer <api_key>"`, or without the header on your own instance.
 
 ## Events
 

--- a/apps/docs/api-reference/queue/jobs.mdx
+++ b/apps/docs/api-reference/queue/jobs.mdx
@@ -8,7 +8,7 @@ description: "List, retry, cancel, and delete video processing jobs"
 Four endpoints over the video job queue: list jobs, then retry, cancel or delete one by ID. All of them need an API key.
 
 ```bash
-curl "http://localhost:3000/queue/jobs?status=error&limit=20" \
+curl "https://media.example.com/queue/jobs?status=error&limit=20" \
   -H "Authorization: Bearer <api_key>"
 ```
 
@@ -88,7 +88,7 @@ POST /queue/jobs/{jobId}/retry
 Re-queues a failed job. `jobId` must have `error` status.
 
 ```bash
-curl -X POST http://localhost:3000/queue/jobs/job_abc123/retry \
+curl -X POST https://media.example.com/queue/jobs/job_abc123/retry \
   -H "Authorization: Bearer <api_key>"
 ```
 
@@ -110,7 +110,7 @@ POST /queue/jobs/{jobId}/cancel
 Cancels a job before it starts processing. `jobId` must have `pending` status.
 
 ```bash
-curl -X POST http://localhost:3000/queue/jobs/job_abc123/cancel \
+curl -X POST https://media.example.com/queue/jobs/job_abc123/cancel \
   -H "Authorization: Bearer <api_key>"
 ```
 
@@ -132,7 +132,7 @@ DELETE /queue/jobs/{jobId}
 Permanently removes a job record from the queue.
 
 ```bash
-curl -X DELETE http://localhost:3000/queue/jobs/job_abc123 \
+curl -X DELETE https://media.example.com/queue/jobs/job_abc123 \
   -H "Authorization: Bearer <api_key>"
 ```
 

--- a/apps/docs/api-reference/queue/stats.mdx
+++ b/apps/docs/api-reference/queue/stats.mdx
@@ -8,7 +8,7 @@ description: "Job counts per status for the video processing queue"
 Counts the job rows currently in the queue table, per status.
 
 ```bash
-curl http://localhost:3000/queue/stats \
+curl https://media.example.com/queue/stats \
   -H "Authorization: Bearer <api_key>"
 ```
 

--- a/apps/docs/api-reference/queue/worker-stats.mdx
+++ b/apps/docs/api-reference/queue/worker-stats.mdx
@@ -8,7 +8,7 @@ description: "Current state of the background video processing worker"
 Reports what the background worker is doing right now: its limits, and how many jobs it is running.
 
 ```bash
-curl http://localhost:3000/queue/worker/stats \
+curl https://media.example.com/queue/worker/stats \
   -H "Authorization: Bearer <api_key>"
 ```
 

--- a/apps/docs/api-reference/storage/copy.mdx
+++ b/apps/docs/api-reference/storage/copy.mdx
@@ -10,7 +10,7 @@ POST /storage/{path}/copy
 ```
 
 ```bash
-curl -X POST http://localhost:3000/storage/photos/portrait.jpg/copy \
+curl -X POST https://cdn.openinary.dev/storage/photos/portrait.jpg/copy \
   -H "Authorization: Bearer <api_key>"
 ```
 

--- a/apps/docs/api-reference/storage/delete.mdx
+++ b/apps/docs/api-reference/storage/delete.mdx
@@ -17,7 +17,7 @@ DELETE /storage/{path}
 ```
 
 ```bash
-curl -X DELETE http://localhost:3000/storage/photos/portrait.jpg \
+curl -X DELETE https://cdn.openinary.dev/storage/photos/portrait.jpg \
   -H "Authorization: Bearer <api_key>"
 ```
 

--- a/apps/docs/api-reference/storage/folders.mdx
+++ b/apps/docs/api-reference/storage/folders.mdx
@@ -10,7 +10,7 @@ GET /storage/folders
 ```
 
 ```bash
-curl http://localhost:3000/storage/folders \
+curl https://cdn.openinary.dev/storage/folders \
   -H "Authorization: Bearer <api_key>"
 ```
 

--- a/apps/docs/api-reference/storage/list.mdx
+++ b/apps/docs/api-reference/storage/list.mdx
@@ -10,7 +10,7 @@ GET /storage
 ```
 
 ```bash
-curl "http://localhost:3000/storage?path=photos/2026" \
+curl "https://cdn.openinary.dev/storage?path=photos/2026" \
   -H "Authorization: Bearer <api_key>"
 ```
 

--- a/apps/docs/api-reference/storage/metadata.mdx
+++ b/apps/docs/api-reference/storage/metadata.mdx
@@ -10,7 +10,7 @@ GET /storage/{path}/metadata
 ```
 
 ```bash
-curl http://localhost:3000/storage/photos/portrait.jpg/metadata \
+curl https://cdn.openinary.dev/storage/photos/portrait.jpg/metadata \
   -H "Authorization: Bearer <api_key>"
 ```
 

--- a/apps/docs/api-reference/storage/move.mdx
+++ b/apps/docs/api-reference/storage/move.mdx
@@ -10,7 +10,7 @@ POST /storage/{path}/move
 ```
 
 ```bash
-curl -X POST http://localhost:3000/storage/photos/portrait.jpg/move \
+curl -X POST https://cdn.openinary.dev/storage/photos/portrait.jpg/move \
   -H "Authorization: Bearer <api_key>" \
   -H "Content-Type: application/json" \
   -d '{"destination": "archive"}'

--- a/apps/docs/api-reference/storage/rename.mdx
+++ b/apps/docs/api-reference/storage/rename.mdx
@@ -10,7 +10,7 @@ PATCH /storage/{path}
 ```
 
 ```bash
-curl -X PATCH http://localhost:3000/storage/photos/portrait.jpg \
+curl -X PATCH https://cdn.openinary.dev/storage/photos/portrait.jpg \
   -H "Authorization: Bearer <api_key>" \
   -H "Content-Type: application/json" \
   -d '{"name": "headshot.jpg"}'

--- a/apps/docs/api-reference/storage/stats.mdx
+++ b/apps/docs/api-reference/storage/stats.mdx
@@ -6,7 +6,7 @@ description: "Aggregate storage and cache usage, and per-folder item counts with
 Three endpoints that answer "how much is in there" without listing everything: aggregate totals for the whole bucket, bounded per-folder summaries, and a recalculation when the totals drift.
 
 ```bash
-curl "http://localhost:3000/storage/folder-summaries?paths=photos,videos" \
+curl "https://cdn.openinary.dev/storage/folder-summaries?paths=photos,videos" \
   -H "Authorization: Bearer <api_key>"
 ```
 
@@ -82,7 +82,7 @@ POST /storage/stats/recalculate
 ```
 
 ```bash
-curl -X POST http://localhost:3000/storage/stats/recalculate \
+curl -X POST https://cdn.openinary.dev/storage/stats/recalculate \
   -H "Authorization: Bearer <api_key>"
 ```
 

--- a/apps/docs/api-reference/video/status.mdx
+++ b/apps/docs/api-reference/video/status.mdx
@@ -6,14 +6,15 @@ description: "Poll the processing status of a queued video transformation"
 When a video transformation is not cached yet, `/t/` answers `202` and returns a `statusUrl`. Poll that URL until the status is `completed`, then request the `/t/` URL again to get the bytes.
 
 ```bash
-curl http://localhost:3000/video-status/w_640/videos/clip.mp4
+curl https://cdn.openinary.dev/video-status/w_640/videos/clip.mp4 \
+  -H "Authorization: Bearer <api_key>"
 ```
 
 ```
 GET /video-status/{transformations}/{path}
 ```
 
-**Auth:** Public (rate limited)
+**Auth:** API key on Cloud, public and rate limited self-hosted. Drop the header when you call your own instance.
 
 <Warning>
   Include the transformation segment in the path. Jobs are keyed on the file
@@ -82,10 +83,11 @@ GET /video-status/{transformations}/{path}/size
 
 Returns the byte size of the processed variant, or `404` if that variant is not ready yet.
 
-**Auth:** Public (rate limited)
+**Auth:** API key on Cloud, public and rate limited self-hosted.
 
 ```bash
-curl http://localhost:3000/video-status/w_640/videos/clip.mp4/size
+curl https://cdn.openinary.dev/video-status/w_640/videos/clip.mp4/size \
+  -H "Authorization: Bearer <api_key>"
 ```
 
 ```json


### PR DESCRIPTION
Follow-up to #131. The API Reference showed `http://localhost:3000` in every example, which reads as a dev-only project and makes every Cloud user rewrite each snippet.

## What changes

- **Shared endpoints** (upload, upload/sign, createfolder, download, storage/*, cache/clear, video-status, queue/events) → `https://cdn.openinary.dev`
- **Self-hosted only pages** (health, api-keys/*, queue/stats|jobs|worker-stats, download-folder, download-zip, `DELETE /invalidate`, the prewarm example) → `https://media.example.com`, matching the rest of the docs
- `api-reference/introduction.mdx`: new **Base URL** section (Cloud / self-hosted table, with `localhost:3000` mentioned only as the development case), an **Authentication** section that leads with Cloud (Settings → API keys, key pinned to a bucket, `Authorization` or `x-api-key`), and a note on Cloud rate limits pointing at `/cloud/api`

## Two accuracy fixes

Without them, the new Cloud examples would return 401 or describe a response that does not exist:

- `/download`, `/video-status` and `/queue/events` are public self-hosted but go through `requireTenant` on Cloud (`apps/cloud/server/worker/app.ts:317-322`). Added the header to those examples, corrected the Auth column in the endpoint table, and moved the `EventSource` example behind a server-side proxy since it cannot send a header.
- `POST /upload` returns a `url` carrying the `/b/{bucketId}/t/...` prefix on Cloud, and no `prewarmedUrls`. Documented under the response example.

## Verified

- The auth headers Cloud accepts (`x-api-key` or `Authorization: Bearer`) against `apiKeyFrom()` in the worker
- The shared / self-hosted-only split against the routes actually registered in `apps/cloud/server/worker/app.ts` and `apps/api/src/index.ts`
- No `localhost:3000` left in `apps/docs/api-reference` outside the Base URL table

26 files, +70/-50. No code changes.