### PR TITLE
fix(image): tolerate malformed JPEG decoding

### DIFF
--- a/packages/core/src/services/transform.service.test.ts
+++ b/packages/core/src/services/transform.service.test.ts
@@ -45,6 +45,75 @@ test("a bare video URL serves the original and queues nothing", async () => {
   assert.equal(result.contentType, "video/mp4");
 });
 
+test("a recoverable JPEG transform failure serves the stored original", async () => {
+  const original = Buffer.from([0xff, 0xd8, 0xff, 0xd9]);
+  const storage = {
+    ...fakeStorage(),
+    downloadOriginal: async () => original,
+    downloadOriginalStream: async () => ({
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(original));
+          controller.close();
+        },
+      }),
+      contentLength: original.length,
+    }),
+  };
+  const service = new TransformService(storage, fakeQueue());
+  const prototype = TransformService.prototype as any;
+  const previous = prototype.processImageFile;
+  prototype.processImageFile = async () => {
+    throw new Error("VipsJpeg: Invalid SOS parameters for sequential JPEG");
+  };
+
+  try {
+    const result = await service.transform({
+      path: "/t/w_640/photos/camera.jpg",
+      userAgent: "",
+      context: {} as any,
+    });
+
+    assert.ok(result.stream);
+    assert.deepEqual(
+      Buffer.from(await new Response(result.stream).arrayBuffer()),
+      original,
+    );
+    assert.equal(result.contentType, "image/jpeg");
+    assert.equal(result.headers?.["X-Transform-Fallback"], "original");
+    assert.equal(result.headers?.["Cache-Control"], "no-store");
+  } finally {
+    prototype.processImageFile = previous;
+  }
+});
+
+test("a non-recoverable JPEG error is not hidden by the original fallback", async () => {
+  const storage = {
+    ...fakeStorage(),
+    downloadOriginal: async () => Buffer.from([0xff, 0xd8, 0xff, 0xd9]),
+  };
+  const service = new TransformService(storage, fakeQueue());
+  const prototype = TransformService.prototype as any;
+  const previous = prototype.processImageFile;
+  prototype.processImageFile = async () => {
+    throw new Error("JPEG encoder unavailable");
+  };
+
+  try {
+    const result = await service.transform({
+      path: "/t/w_640/photos/camera.jpg",
+      userAgent: "",
+      context: {} as any,
+    });
+
+    assert.equal(result.contentType, "text/plain");
+    assert.match(result.buffer!.toString(), /JPEG encoder unavailable/);
+    assert.equal(result.headers?.["X-Transform-Fallback"], undefined);
+  } finally {
+    prototype.processImageFile = previous;
+  }
+});
+
 test("a pending video transform answers 202 instead of the original", async () => {
   const service = new TransformService(
     fakeStorage(),

--- a/packages/core/src/services/transform.service.ts
+++ b/packages/core/src/services/transform.service.ts
@@ -26,6 +26,13 @@ import {
 const isVideo = (ext: string | undefined): ext is string =>
   !!ext && VIDEO_FORMATS.has(ext);
 
+const isRecoverableJpegError = (error: unknown, ext: string | undefined) => {
+  if (!ext?.match(/^jpe?g$/i)) return false;
+  const message = error instanceof Error ? error.message : String(error);
+  return /VipsJpeg:\s*Invalid SOS parameters for sequential JPEG/i.test(message);
+};
+
+
 // Types for the service
 export interface TransformRequest {
   path: string;
@@ -340,7 +347,7 @@ export class TransformService {
       };
     }
 
-// Prepare source file
+    // Prepare source file
     const sourcePath = await prepareSourceFile(
       this.storage,
       filePath,
@@ -361,12 +368,34 @@ export class TransformService {
       // the only two possibilities here: anything else already returned a
       // 400 above, before this file was staged.
       if (isTransformableImage) {
-        const result = await this.processImageFile(
-          sourcePath,
-          effectiveParams,
-          userAgent,
-          acceptHeader,
-        );
+        let result: Awaited<ReturnType<TransformService["processImageFile"]>>;
+        try {
+          result = await this.processImageFile(
+            sourcePath,
+            effectiveParams,
+            userAgent,
+            acceptHeader,
+          );
+        } catch (error) {
+          // Some camera JPEGs are browser-readable but rejected by libjpeg's
+          // strict SOS validation. Do not make the uploaded original
+          // unreachable: serve it untouched, without writing it into the
+          // transformed cache under a misleading key.
+          if (!isRecoverableJpegError(error, ext)) throw error;
+          const fallback = await this.streamOriginal(
+            filePath,
+            localPath,
+            ext ?? "jpg",
+            sourceUrl,
+          );
+          fallback.headers["Cache-Control"] = "no-store";
+          fallback.headers["X-Transform-Fallback"] = "original";
+          logger.warn(
+            { error: serializeError(error), filePath },
+            "JPEG transform failed; serving original",
+          );
+          return fallback;
+        }
         buffer = result.buffer;
         contentType = result.contentType;
         optimizationResult = result.optimizationResult;

--- a/packages/core/src/utils/image/compression.ts
+++ b/packages/core/src/utils/image/compression.ts
@@ -1,6 +1,7 @@
 import sharp from 'sharp';
 import { TransformParams, ImageFormat, ImageAnalysis, OptimizationResult } from './types';
 import logger, { serializeError } from '../logger';
+import { SHARP_INPUT_OPTIONS } from './sharp-options';
 
 export class Compression {
   /** Formats applyFormat() can actually encode. Excludes "auto". */
@@ -26,12 +27,12 @@ export class Compression {
     acceptHeader?: string
   ): Promise<OptimizationResult> {
     
-    const originalBuffer = await sharp(inputPath).toBuffer();
+    const originalBuffer = await sharp(inputPath, SHARP_INPUT_OPTIONS).toBuffer();
     const originalSize = originalBuffer.length;
     
     // CONTENT ANALYSIS
     const analysis = await this.analyzeImage(inputPath);
-    const metadata = await sharp(inputPath).metadata();
+    const metadata = await sharp(inputPath, SHARP_INPUT_OPTIONS).metadata();
     
     // If format is explicitly specified, use it directly (no size comparison needed)
     // "auto" is not an explicit format — it falls through to format size comparison below.
@@ -192,7 +193,7 @@ export class Compression {
     metadata: sharp.Metadata,
     originalSize: number
   ): sharp.Sharp {
-    let pipeline = sharp(inputPath);
+    let pipeline = sharp(inputPath, SHARP_INPUT_OPTIONS);
     
     // Resolution reduction only for extremely large files
     if (originalSize > 5 * 1024 * 1024) { // > 5MB
@@ -265,7 +266,7 @@ export class Compression {
    * Analyzes image content to optimize compression (simplified for speed)
    */
   private async analyzeImage(inputPath: string): Promise<ImageAnalysis> {
-    const image = sharp(inputPath);
+    const image = sharp(inputPath, SHARP_INPUT_OPTIONS);
     const metadata = await image.metadata();
     
     // Simplified analysis based only on metadata (no expensive stats calculation)

--- a/packages/core/src/utils/image/index.ts
+++ b/packages/core/src/utils/image/index.ts
@@ -8,6 +8,7 @@ import { applyRotation } from './rotation';
 import { applyQuality } from './quality';
 import { applyResizeComposite } from './param-registry';
 import { applyRoundCorners } from './round-corners';
+import { SHARP_INPUT_OPTIONS } from './sharp-options';
 
 /**
  * Decode a PSD file into a Sharp instance via raw RGBA pixel data.
@@ -37,7 +38,7 @@ export * from './param-registry';
 export const transformImage = async (inputPath: string, params: TransformParams): Promise<Buffer> => {
   let image = inputPath.toLowerCase().endsWith('.psd')
     ? await decodePsd(inputPath)
-    : sharp(inputPath);
+    : sharp(inputPath, SHARP_INPUT_OPTIONS);
 
   // Convert TransformParams to a record for easier access
   const paramsRecord: Record<string, string> = {

--- a/packages/core/src/utils/image/sharp-options.ts
+++ b/packages/core/src/utils/image/sharp-options.ts
@@ -1,0 +1,8 @@
+import sharp from 'sharp';
+
+/**
+ * Accept recoverable decoder warnings from camera and phone images. Browsers
+ * commonly display these files, and libvips can usually decode them when its
+ * failure threshold is lowered.
+ */
+export const SHARP_INPUT_OPTIONS: sharp.SharpOptions = { failOn: 'none' };


### PR DESCRIPTION
## Summary

Fixes JPEG processing failures for camera images that libvips rejects with:

`VipsJpeg: Invalid SOS parameters for sequential JPEG`

## Changes

- Configure shared Sharp input options with `failOn: 'none'`.
- Detect only the known recoverable JPEG SOS error.
- Serve the original file through the existing streaming path when transformation fails.
- Avoid writing original bytes into transformed cache.
- Mark fallback responses with `X-Transform-Fallback: original` and `Cache-Control: no-store`.
- Add regression coverage for recoverable and non-recoverable JPEG errors.

## Validation

- Core type-check passes.
- 90 core tests pass.
- `git diff --check` passes.
- Verified with Docker full-stack setup.

Refs #136